### PR TITLE
Apply build changes from tpm2-tss

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 Makefile
 Makefile.in
 aclocal.m4
+aminclude_static.am
 autom4te.cache/
 compile
 config.guess

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -2,6 +2,7 @@
 
 ## GNU/Linux
 * GNU Autoconf
+* GNU Autoconf Archive
 * GNU Automake
 * GNU Libtool
 * C compiler
@@ -17,6 +18,7 @@
 sudo apt -y install \
   build-essential \
   autoconf \
+  autoconf-archive \
   automake \
   m4 \
   libtool \

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@
 
 ### Initialize global variables used throughout the file ###
 INCLUDE_DIRS    = -I$(srcdir)/include -I$(srcdir)/src
-ACLOCAL_AMFLAGS = -I m4
+ACLOCAL_AMFLAGS = -I m4 --install
 AM_CFLAGS       = $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(TSS2_ESYS_CFLAGS) \
                   $(QRENCODE_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,13 @@ MOSTLYCLEANFILES =
 
 ### Add ax_* rules ###
 # ax_code_coverage
+if AUTOCONF_CODE_COVERAGE_2019_01_06
+include $(top_srcdir)/aminclude_static.am
+clean-local: code-coverage-clean
+distclean-local: code-coverage-dist-clean
+else
 @CODE_COVERAGE_RULES@
+endif
 
 ### Library ###
 lib_LTLIBRARIES += libtpm2-totp.la

--- a/configure.ac
+++ b/configure.ac
@@ -59,6 +59,10 @@ AX_ADD_LINK_FLAG([-Wl,-z,now])
 AX_ADD_LINK_FLAG([-Wl,-z,relro])
 
 AX_CODE_COVERAGE
+m4_ifdef([_AX_CODE_COVERAGE_RULES],
+         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [true])],
+         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [false])])
+AX_ADD_AM_MACRO_STATIC([])
 
 AC_ARG_ENABLE([debug],
             [AS_HELP_STRING([--enable-debug],


### PR DESCRIPTION
This PR applies the following recent changes to the build system from tpm2-tss:
- Support for Autoconf Archive 2019.01.06: https://github.com/tpm2-software/tpm2-tss/pull/1238, including the fix for older versions in https://github.com/tpm2-software/tpm2-tss/pull/1256
- Installation of the aclocal macros to the `m4/` subdirectory: https://github.com/tpm2-software/tpm2-tss/pull/1245