### PR TITLE
build: install existing man pages even if pandoc is not available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -75,10 +75,13 @@ AUTHORS:
 EXTRA_DIST += AUTHORS
 CLEANFILES += AUTHORS
 
-if HAVE_PANDOC
+if HAVE_MAN_PAGES
 ### Man Pages
 man1_MANS = \
-    man/tpm2-totp.1
+    man/man1/tpm2-totp.1
+endif
+
+if HAVE_PANDOC
 # If pandoc is enabled, we want to generate the manpages for the dist tarball
 EXTRA_DIST += \
     $(man1_MANS)
@@ -91,15 +94,11 @@ dist-hook:
 	@exit 1
 endif
 
-define man_dir
-    mkdir man 2>/dev/null || test -d man
-endef
+man/man1/%.1: man/%.1.md
+	$(AM_V_GEN)mkdir -p man/man1 && cat $< | $(PANDOC) -s -t man >$@
 
-man/%.1: man/%.1.md
-	$(AM_V_GEN)$(call man_dir) && cat $< | $(PANDOC) -s -t man >$@
-
-man/%.3: man/%.3.md
-	$(AM_V_GEN)$(call man_dir) && cat $< | $(PANDOC) -s -t man >$@
+man/man3/%.3: man/%.3.md
+	$(AM_V_GEN)mkdir -p man/man3 && cat $< | $(PANDOC) -s -t man >$@
 
 EXTRA_DIST += \
     man/tpm2-totp.1.md

--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,7 @@ AC_PATH_PROG([PANDOC], [pandoc])
 AS_IF([test -z "$PANDOC"],
     [AC_MSG_WARN([Required executable pandoc not found, man pages will not be built])])
 AM_CONDITIONAL([HAVE_PANDOC],[test -n "$PANDOC"])
+AM_CONDITIONAL([HAVE_MAN_PAGES],[test -d "${srcdir}/man/man1" -o -n "$PANDOC"])
 
 AC_OUTPUT
 


### PR DESCRIPTION
Currently man pages are only installed if pandoc is available on the system. Since release tarballs already include the generated man pages, the dependency on pandoc can be avoided on the target system. To do so, use the solution from tpm2-tools to have a conditional [`HAVE_MAN_PAGES`](https://github.com/tpm2-software/tpm2-tools/blob/bd188cb7fc9985081eb8b931f80d196f594539fc/configure.ac#L23) that tracks whether the folder with the generated man pages already exists.