### PR TITLE
Remove SHA384 from default banks

### DIFF
--- a/src/libtpm2-totp.c
+++ b/src/libtpm2-totp.c
@@ -22,7 +22,7 @@
 #define SECRETLEN 20
 
 #define DEFAULT_PCRS (0b000000000000000000010101)
-#define DEFAULT_BANKS (0b111)
+#define DEFAULT_BANKS (0b11)
 #define DEFAULT_NV 0x018094AF
 
 const TPM2B_DIGEST ownerauth = { .size = 0 };

--- a/src/tpm2-totp.c
+++ b/src/tpm2-totp.c
@@ -27,7 +27,7 @@ char *help =
     "Usage: [options] {generate|calculate|reseal|recover|clean}\n"
     "Options:\n"
     "    -h, --help      print help\n"
-    "    -b, --banks     Selected PCR banks (default: SHA1,SHA256,SHA384)\n"
+    "    -b, --banks     Selected PCR banks (default: SHA1,SHA256)\n"
     "    -N, --nvindex   TPM NV index to store data (default: 0x018094AF)\n"
     "    -P, --password  Password for recovery/resealing (default: None)\n"
     "    -p, --pcrs      Selected PCR registers (default: 0,2,4,6)\n"


### PR DESCRIPTION
Some TPMs give weird errors if SHA384 is selected as a bank.
Removing it from default banks, thus only enabling SHA1 and SHA256 by default.