### PR TITLE
 Make TCTI configurable and force the tests to use the simulator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,9 +98,9 @@ script:
     fi
   - $SCAN_PREFIX ../configure $CONFIGURE_OPTIONS --enable-integration
   - $SCAN_PREFIX make -j$(nproc)
-  - make -j1 check
+  - make -j$(nproc) check
   - cat test-suite.log
-  - make -j1 distcheck
+  - make -j$(nproc) distcheck
   - cat config.log $(find -name test-suit.log) || true
   - popd
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,12 @@
 * tpm2-tss >= 2.0
 * libqrencode
 * pandoc
-* liboath (for test-suit)
+
+For the integration test suite:
+* liboath
+* tpm_server
+* realpath
+* ss
 
 ## Ubuntu
 ```
@@ -26,7 +31,8 @@ sudo apt -y install \
   pkg-config \
   libqrencode-dev \
   pandoc \
-  liboath-dev
+  liboath-dev \
+  iproute2
 git clone --depth=1 http://www.github.com/tpm2-software/tpm2-tss
 cd tpm2-tss
 ./bootstrap
@@ -40,7 +46,7 @@ sudo make install
 ./bootstrap
 ./configure
 make -j$(nproc)
-make -j1 check
+make -j$(nproc) check
 sudo make install
 ```
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,7 @@ DISTCLEANFILES += $(pkgconfig_DATA)
 ### Executable ###
 bin_PROGRAMS += tpm2-totp
 
-tpm2_totp_SOURCES = src/tpm2-totp.c
+tpm2_totp_SOURCES = src/tpm2-totp.c src/tpm2-totp-tcti.c src/tpm2-totp-tcti.h
 tpm2_totp_LDADD = $(AM_LDADD) libtpm2-totp.la
 tpm2_totp_LDFLAGS = $(AM_LDFLAGS)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -59,11 +59,14 @@ endif #INTEGRATION
 TESTS_SHELL = test/libtpm2-totp.sh \
               test/tpm2-totp.sh
 EXTRA_DIST += $(TESTS_SHELL)
+TEST_EXTENSIONS = .sh
+SH_LOG_COMPILER = $(srcdir)/test/sh_log_compiler.sh
+EXTRA_DIST += $(SH_LOG_COMPILER)
 
 if INTEGRATION
 check_PROGRAMS += libtpm2-totp
 
-libtpm2_totp_SOURCES = test/libtpm2-totp.c
+libtpm2_totp_SOURCES = test/libtpm2-totp.c src/tpm2-totp-tcti.c src/tpm2-totp-tcti.h
 libtpm2_totp_CFLAGS = $(AM_CFLAGS) $(OATH_CFLAGS)
 libtpm2_totp_LDADD = $(AM_LDADD) $(OATH_LIBS) libtpm2-totp.la
 libtpm2_totp_LDFLAGS = $(AM_LDFLAGS) $(OATH_LDFLAGS)

--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,18 @@ AC_ARG_ENABLE([integration],
                             [build integration tests against TPM])],,
             [enable_integration=no])
 AM_CONDITIONAL([INTEGRATION], [test "x$enable_integration" != xno])
-AS_IF([test "x$enable_integration" != xno], [PKG_CHECK_MODULES([OATH],[liboath])])
+AS_IF([test "x$enable_integration" != xno],
+      [PKG_CHECK_MODULES([OATH],[liboath])
+       AC_CHECK_PROG([tpm_server], [tpm_server], [yes])
+       AS_IF([test "x$tpm_server" != xyes],
+             [AC_MSG_ERROR([Integration tests require the tpm_server executable])])
+       AC_CHECK_PROG([realpath], [realpath], [yes])
+       AS_IF([test "x$realpath" != xyes],
+             [AC_MSG_ERROR([Integration tests require the realpath executable])])
+       AC_CHECK_PROG([ss], [ss], [yes])
+       AS_IF([test "x$ss" != xyes],
+             [AC_MSG_ERROR([Integration tests require the ss executable])])
+      ])
 
 AC_OUTPUT
 

--- a/include/tpm2-totp.h
+++ b/include/tpm2-totp.h
@@ -17,30 +17,35 @@
 
 int
 tpm2totp_generateKey(uint32_t pcrs, uint32_t banks, const char *password,
+                     TSS2_TCTI_CONTEXT *tcti_context,
                      uint8_t **secret, size_t *secret_size,
                      uint8_t **keyBlob, size_t *keyBlob_size);
 
 int
 tpm2totp_reseal(const uint8_t *keyBlob, size_t keyBlob_size,
                 const char *password, uint32_t pcrs, uint32_t banks,
+                TSS2_TCTI_CONTEXT *tcti_context,
                 uint8_t **newBlob, size_t *newBlob_size);
 
 int
-tpm2totp_storeKey_nv(const uint8_t *keyBlob, size_t keyBlob_size, uint32_t nv);
+tpm2totp_storeKey_nv(const uint8_t *keyBlob, size_t keyBlob_size, uint32_t nv,
+                     TSS2_TCTI_CONTEXT *tcti_context);
 
 int
-tpm2totp_loadKey_nv(uint32_t nv, uint8_t **keyBlob, size_t *keyBlob_size);
+tpm2totp_loadKey_nv(uint32_t nv, TSS2_TCTI_CONTEXT *tcti_context,
+                    uint8_t **keyBlob, size_t *keyBlob_size);
 
 int
-tpm2totp_deleteKey_nv(uint32_t nv);
+tpm2totp_deleteKey_nv(uint32_t nv, TSS2_TCTI_CONTEXT *tcti_context);
 
 int
 tpm2totp_calculate(const uint8_t *keyBlob, size_t keyBlob_size,
+                   TSS2_TCTI_CONTEXT *tcti_context,
                    time_t *now, uint64_t *otp);
 
 int
 tpm2totp_getSecret(const uint8_t *keyBlob, size_t keyBlob_size, 
-                   const char *password,
+                   const char *password, TSS2_TCTI_CONTEXT *tcti_context,
                    uint8_t **secret, size_t *secret_size);
 
 #endif /* TPM2_TOTP_H */

--- a/man/tpm2-totp.1.md
+++ b/man/tpm2-totp.1.md
@@ -24,23 +24,23 @@ options.
 
   * `generate`:
     Generate a new TOTP seret.
-    Possible options: `-b, -N, -p, -P`
+    Possible options: `-b`, `-N`, `-p`, `-P`, `-T`
 
   * `calculate`:
     Calculate a TOTP value.
-    Possible options: `-N, -t`
+    Possible options: `-N`, `-t`, `-T`
 
   * `reseal`:
     Reseal TOTP secret to new PCRs, banks or values.
-    Possible options: `-b, -N, -p, -P`(required)
+    Possible options: `-b`, `-N`, `-p`, `-P` (required), `-T`
 
   * `recover`:
     Recover the TOTP secret and display it again.
-    Possible Options: `-N, -P`(required)
+    Possible Options: `-N`, `-P` (required), `-T`
 
   * `clean`:
     Delete the consumed NV index.
-    Possible Options: `-N`
+    Possible Options: `-N`, `-T`
 
 ## OPTIONS
 
@@ -61,6 +61,17 @@ options.
 
   * `-t`, `--time`:
     Display the date/time of the TOTP calculation (commands: calculate)
+
+  * `-T <tcti-name>[:<tcti-config>]`, `--tcti <tcti-name>[:<tcti-config>]`:
+    Select the TCTI to use. The raw *tcti-name* is used to load a dynamic TCTI
+    interface using *dlopen(3)*. If present, the option config *tcti-config*
+    is passed verbatim to the the chosen TCTI.
+
+    The TCTI can additionally be specified using the environment variable
+    `TPM2TOTP_TCTI`. If both the command line option and the environment
+    variable are present, the command line option is used.
+
+    If no TCTI is specified, the default TCTI configured on the system is used.
 
   * `-v`, `--verbose`:
     Print verbose messages
@@ -113,6 +124,15 @@ used. By default, 0x018094AF is used and recommended.
 ./tpm2-totp -N 0x01800001 calculate
 ./tpm2-totp -N 0x01800001 -P verysecret recover
 ./tpm2-totp -N 0x01800001 -P verysecret reseal
+```
+
+## TCTI configuration
+All commands take the `-T` option or the `TPM2TOTP_TCTI` environment variable
+to specify the TCTI to be used. If the TCTI is not specified explicitly, the
+default TCTI configured on the system is used. To e.g. use the TPM simulator
+bound to a given port, use
+```
+./tpm2-totp -T libtss2-tcti-mssim.so.0:port=2321 Ygenerate
 ```
 
 # RETURNS

--- a/src/tpm2-totp-tcti.c
+++ b/src/tpm2-totp-tcti.c
@@ -1,0 +1,143 @@
+/* SPDX-License-Identifier: BSD-3 */
+/*******************************************************************************
+ * Copyright 2019, Jonas Witschel
+ * All rights reserved.
+ *******************************************************************************/
+
+#include "tpm2-totp-tcti.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+#include <tss2/tss2_tcti.h>
+
+#define ERR(...) fprintf(stderr, __VA_ARGS__)
+
+#define TPM2TOTP_ENV_TCTI "TPM2TOTP_TCTI"
+#define TSS2_TCTI_SO_FORMAT "libtss2-tcti-%s.so.0"
+
+static struct tcti {
+    void *dlhandle;
+    TSS2_TCTI_CONTEXT *context;
+} tcti;
+
+static void
+tcti_parse_string(char *str, char **path, char **conf)
+{
+    *path = str;
+    char *split = strchr(str, ':');
+    if (split == NULL) {
+        *conf = NULL;
+    } else {
+        split[0] = '\0';
+        *conf = &split[1];
+    }
+}
+
+static void*
+tcti_dlopen(const char *path)
+{
+    void* dlhandle;
+
+    dlhandle = dlopen(path, RTLD_LAZY);
+
+    if (dlhandle) {
+        return dlhandle;
+    } else {
+        /* Expand <tcti> to libtss2-tcti-<tcti>.so.0 */
+        char *dlname;
+
+        int size = snprintf(NULL, 0, TSS2_TCTI_SO_FORMAT, path);
+        if (size <= 0) {
+            ERR("Could not open TCTI %s.\n", path);
+            return NULL;
+        }
+
+        dlname = malloc(size+1);
+        if (!dlname) {
+            ERR("oom");
+            return NULL;
+        }
+
+        snprintf(dlname, size+1, TSS2_TCTI_SO_FORMAT, path);
+        dlhandle = dlopen(dlname, RTLD_LAZY);
+        free(dlname);
+        return dlhandle;
+    }
+}
+
+int
+tcti_init(char *str, TSS2_TCTI_CONTEXT **context)
+{
+    *context = tcti.context = NULL;
+
+    /* If no option is given, load from environment or use default TCTI */
+    if (!str) {
+        str = getenv(TPM2TOTP_ENV_TCTI);
+        if (!str) {
+            return 0;
+        }
+    }
+
+    char* path;
+    char* conf;
+    tcti_parse_string(str, &path, &conf);
+    if (path[0] == '\0') {
+       ERR("No TCTI given.\n");
+       return 1;
+    }
+
+    tcti.dlhandle = tcti_dlopen(path);
+    if (!tcti.dlhandle) {
+        ERR("Could not open TCTI '%s'.\n", path);
+        return 1;
+    }
+
+    TSS2_TCTI_INFO_FUNC infofn =
+        (TSS2_TCTI_INFO_FUNC) dlsym(tcti.dlhandle, TSS2_TCTI_INFO_SYMBOL);
+    if (!infofn) {
+        dlclose(tcti.dlhandle);
+        ERR("Symbol '%s' not found in library '%s'.\n", TSS2_TCTI_INFO_SYMBOL, path);
+        return 1;
+    }
+    const TSS2_TCTI_INFO *info = infofn();
+    const TSS2_TCTI_INIT_FUNC init = info->init;
+
+    size_t context_size;
+    if (init(NULL, &context_size, conf) != TPM2_RC_SUCCESS) {
+        ERR("TCTI init routine failed.\n");
+        goto err;
+    }
+
+    tcti.context = (TSS2_TCTI_CONTEXT*) malloc(context_size);
+    if (!tcti.context) {
+        ERR("oom");
+        goto err;
+    }
+
+    if (init(tcti.context, &context_size, conf) != TPM2_RC_SUCCESS) {
+        ERR("TCTI context creation failed.\n");
+        goto err;
+    }
+
+    *context = tcti.context;
+    return 0;
+
+err:
+    free(tcti.context);
+    tcti.context = NULL;
+    dlclose(tcti.dlhandle);
+    tcti.dlhandle = NULL;
+    return 1;
+}
+
+void
+tcti_finalize()
+{
+    if (tcti.context) {
+        Tss2_Tcti_Finalize(tcti.context);
+        free(tcti.context);
+        dlclose(tcti.dlhandle);
+    }
+}

--- a/src/tpm2-totp-tcti.h
+++ b/src/tpm2-totp-tcti.h
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: BSD-3 */
+/*******************************************************************************
+ * Copyright 2019, Jonas Witschel
+ * All rights reserved.
+ *******************************************************************************/
+
+#ifndef TPM2_TOTP_TCTI_H
+#define TPM2_TOTP_TCTI_H
+
+#include <tss2/tss2_tcti.h>
+
+int
+tcti_init(char *str, TSS2_TCTI_CONTEXT **context);
+
+void
+tcti_finalize();
+
+#endif /* TPM2_TOTP_TCTI_H */

--- a/src/tpm2-totp.c
+++ b/src/tpm2-totp.c
@@ -305,12 +305,12 @@ main(int argc, char **argv)
 
     switch(opt.cmd) {
     case CMD_GENERATE:
-        rc = tpm2totp_generateKey(opt.pcrs, opt.banks, opt.password,
+        rc = tpm2totp_generateKey(opt.pcrs, opt.banks, opt.password, NULL,
                                   &secret, &secret_size, 
                                   &keyBlob, &keyBlob_size);
         chkrc(rc, exit(1));
 
-        rc = tpm2totp_storeKey_nv(keyBlob, keyBlob_size, opt.nvindex);
+        rc = tpm2totp_storeKey_nv(keyBlob, keyBlob_size, opt.nvindex, NULL);
         free(keyBlob);
         chkrc(rc, exit(1));
 
@@ -327,10 +327,10 @@ main(int argc, char **argv)
         free(url);
         break;
     case CMD_CALCULATE:
-        rc = tpm2totp_loadKey_nv(opt.nvindex, &keyBlob, &keyBlob_size);
+        rc = tpm2totp_loadKey_nv(opt.nvindex, NULL, &keyBlob, &keyBlob_size);
         chkrc(rc, exit(1));
 
-        rc = tpm2totp_calculate(keyBlob, keyBlob_size, &now, &totp);
+        rc = tpm2totp_calculate(keyBlob, keyBlob_size, NULL, &now, &totp);
         free(keyBlob);
         chkrc(rc, exit(1));
         if (opt.time) {
@@ -341,27 +341,27 @@ main(int argc, char **argv)
         printf("%s%06" PRIu64, timestr, totp);
         break;
     case CMD_RESEAL:
-        rc = tpm2totp_loadKey_nv(opt.nvindex, &keyBlob, &keyBlob_size);
+        rc = tpm2totp_loadKey_nv(opt.nvindex, NULL, &keyBlob, &keyBlob_size);
         chkrc(rc, exit(1));
 
         rc = tpm2totp_reseal(keyBlob, keyBlob_size, opt.password, opt.pcrs,
-                             opt.banks, &newBlob, &newBlob_size);
+                             opt.banks, NULL, &newBlob, &newBlob_size);
         free(keyBlob);
         chkrc(rc, exit(1));
 
         //TODO: Are your sure ?
-        rc = tpm2totp_deleteKey_nv(opt.nvindex);
+        rc = tpm2totp_deleteKey_nv(opt.nvindex, NULL);
         chkrc(rc, exit(1));
 
-        rc = tpm2totp_storeKey_nv(newBlob, newBlob_size, opt.nvindex);
+        rc = tpm2totp_storeKey_nv(newBlob, newBlob_size, opt.nvindex, NULL);
         free(newBlob);
         chkrc(rc, exit(1));
         break;
     case CMD_RECOVER:
-        rc = tpm2totp_loadKey_nv(opt.nvindex, &keyBlob, &keyBlob_size);
+        rc = tpm2totp_loadKey_nv(opt.nvindex, NULL, &keyBlob, &keyBlob_size);
         chkrc(rc, exit(1));
 
-        rc = tpm2totp_getSecret(keyBlob, keyBlob_size, opt.password,
+        rc = tpm2totp_getSecret(keyBlob, keyBlob_size, opt.password, NULL,
                                 &secret, &secret_size);
         free(keyBlob);
         chkrc(rc, exit(1));
@@ -380,7 +380,7 @@ main(int argc, char **argv)
         break;
     case CMD_CLEAN:
         //TODO: Are your sure ?
-        rc = tpm2totp_deleteKey_nv(opt.nvindex);
+        rc = tpm2totp_deleteKey_nv(opt.nvindex, NULL);
         chkrc(rc, exit(1));
         break;
     default:

--- a/test/libtpm2-totp.c
+++ b/test/libtpm2-totp.c
@@ -29,11 +29,11 @@ main(int argc, char **argv)
 
 /**********/
 
-    rc = tpm2totp_generateKey(0x00, 0x00, PWD,
+    rc = tpm2totp_generateKey(0x00, 0x00, PWD, NULL,
                               &secret, &secret_size, &keyBlob, &keyBlob_size);
     chkrc(rc, exit(1));
 
-    rc = tpm2totp_calculate(keyBlob, keyBlob_size, &now, &totp);
+    rc = tpm2totp_calculate(keyBlob, keyBlob_size, NULL, &now, &totp);
     chkrc(rc, exit(1));
     snprintf(&totp_string[0], 7, "%.*ld", 6, totp);
 
@@ -47,10 +47,10 @@ main(int argc, char **argv)
 
 /**********/
 
-    rc = tpm2totp_reseal(keyBlob, keyBlob_size, PWD, 0, 0, &newBlob, &newBlob_size);
+    rc = tpm2totp_reseal(keyBlob, keyBlob_size, PWD, 0, 0, NULL, &newBlob, &newBlob_size);
     chkrc(rc, exit(1));
 
-    rc = tpm2totp_calculate(newBlob, newBlob_size, &now, &totp);
+    rc = tpm2totp_calculate(newBlob, newBlob_size, NULL, &now, &totp);
     chkrc(rc, exit(1));
     snprintf(&totp_string[0], 7, "%.*ld", 6, totp);
 
@@ -65,26 +65,26 @@ main(int argc, char **argv)
 
 /**********/
 
-    rc = tpm2totp_getSecret(keyBlob, keyBlob_size, PWD,
+    rc = tpm2totp_getSecret(keyBlob, keyBlob_size, PWD, NULL,
                             &secret, &secret_size);
     chkrc(rc, exit(1));
 
 /**********/
 
-    rc = tpm2totp_storeKey_nv(keyBlob, keyBlob_size, 0);
+    rc = tpm2totp_storeKey_nv(keyBlob, keyBlob_size, 0, NULL);
     chkrc(rc, exit(1));
 
     free(keyBlob);
-    rc = tpm2totp_loadKey_nv(0, &keyBlob, &keyBlob_size);
+    rc = tpm2totp_loadKey_nv(0, NULL, &keyBlob, &keyBlob_size);
     chkrc(rc, exit(1));
 
-    rc = tpm2totp_deleteKey_nv(0);
+    rc = tpm2totp_deleteKey_nv(0, NULL);
     chkrc(rc, exit(1));
 
-    rc = tpm2totp_storeKey_nv(keyBlob, keyBlob_size, 0);
+    rc = tpm2totp_storeKey_nv(keyBlob, keyBlob_size, 0, NULL);
     chkrc(rc, exit(1));
 
-    rc = tpm2totp_deleteKey_nv(0);
+    rc = tpm2totp_deleteKey_nv(0, NULL);
     chkrc(rc, exit(1));
 
 /***********/

--- a/test/libtpm2-totp.c
+++ b/test/libtpm2-totp.c
@@ -10,6 +10,8 @@
 #include <time.h>
 #include <liboath/oath.h>
 
+#include "tpm2-totp-tcti.h"
+
 #define chkrc(rc, cmd) if (rc != TSS2_RC_SUCCESS) {\
     fprintf(stderr, "ERROR in %s:%i: 0x%08x\n", __FILE__, __LINE__, rc); cmd; }
 
@@ -21,75 +23,92 @@ main(int argc, char **argv)
     (void)(argc); (void)(argv);
 
     int rc;
-    uint8_t *secret, *keyBlob, *newBlob;
+    uint8_t *secret = NULL;
+    uint8_t *keyBlob = NULL;
+    uint8_t *newBlob = NULL;
     size_t secret_size, keyBlob_size, newBlob_size;
     uint64_t totp;
     char totp_string[7], totp_check[7];
     time_t now;
+    TSS2_TCTI_CONTEXT *tcti_context;
 
 /**********/
 
-    rc = tpm2totp_generateKey(0x00, 0x00, PWD, NULL,
-                              &secret, &secret_size, &keyBlob, &keyBlob_size);
-    chkrc(rc, exit(1));
+    /* Initialize from environment variable */
+    if (tcti_init(NULL, &tcti_context) != 0) {
+        goto err;
+    }
 
-    rc = tpm2totp_calculate(keyBlob, keyBlob_size, NULL, &now, &totp);
-    chkrc(rc, exit(1));
+/**********/
+
+    rc = tpm2totp_generateKey(0x00, 0x00, PWD, tcti_context,
+                              &secret, &secret_size, &keyBlob, &keyBlob_size);
+    chkrc(rc, goto err);
+
+    rc = tpm2totp_calculate(keyBlob, keyBlob_size, tcti_context, &now, &totp);
+    chkrc(rc, goto err);
     snprintf(&totp_string[0], 7, "%.*ld", 6, totp);
 
     rc = oath_totp_generate((char *)secret, secret_size, now, 30, 0, 6, &totp_check[0]);
-    chkrc(rc, exit(1));
+    chkrc(rc, goto err);
 
     if (!!memcmp(&totp_string[0], &totp_check[0], 7)) {
         fprintf(stderr, "TPM's %s != %s\n", totp_string, totp_check);
-        exit(1);
+        goto err;
     }    
 
 /**********/
 
-    rc = tpm2totp_reseal(keyBlob, keyBlob_size, PWD, 0, 0, NULL, &newBlob, &newBlob_size);
-    chkrc(rc, exit(1));
+    rc = tpm2totp_reseal(keyBlob, keyBlob_size, PWD, 0, 0, tcti_context, &newBlob, &newBlob_size);
+    chkrc(rc, goto err);
 
-    rc = tpm2totp_calculate(newBlob, newBlob_size, NULL, &now, &totp);
-    chkrc(rc, exit(1));
+    rc = tpm2totp_calculate(newBlob, newBlob_size, tcti_context, &now, &totp);
+    chkrc(rc, goto err);
     snprintf(&totp_string[0], 7, "%.*ld", 6, totp);
 
     rc = oath_totp_generate((char *)secret, secret_size, now, 30, 0, 6, &totp_check[0]);
-    chkrc(rc, exit(1));
+    chkrc(rc, goto err);
 
     if (!!memcmp(&totp_string[0], &totp_check[0], 7)) {
         fprintf(stderr, "TPM's %s != %s\n", totp_string, totp_check);
-        exit(1);
+        goto err;
     }
     free(newBlob);
 
 /**********/
 
-    rc = tpm2totp_getSecret(keyBlob, keyBlob_size, PWD, NULL,
+    rc = tpm2totp_getSecret(keyBlob, keyBlob_size, PWD, tcti_context,
                             &secret, &secret_size);
-    chkrc(rc, exit(1));
+    chkrc(rc, goto err);
 
 /**********/
 
-    rc = tpm2totp_storeKey_nv(keyBlob, keyBlob_size, 0, NULL);
-    chkrc(rc, exit(1));
+    rc = tpm2totp_storeKey_nv(keyBlob, keyBlob_size, 0, tcti_context);
+    chkrc(rc, goto err);
 
     free(keyBlob);
-    rc = tpm2totp_loadKey_nv(0, NULL, &keyBlob, &keyBlob_size);
-    chkrc(rc, exit(1));
+    rc = tpm2totp_loadKey_nv(0, tcti_context, &keyBlob, &keyBlob_size);
+    chkrc(rc, goto err);
 
-    rc = tpm2totp_deleteKey_nv(0, NULL);
-    chkrc(rc, exit(1));
+    rc = tpm2totp_deleteKey_nv(0, tcti_context);
+    chkrc(rc, goto err);
 
-    rc = tpm2totp_storeKey_nv(keyBlob, keyBlob_size, 0, NULL);
-    chkrc(rc, exit(1));
+    rc = tpm2totp_storeKey_nv(keyBlob, keyBlob_size, 0, tcti_context);
+    chkrc(rc, goto err);
 
-    rc = tpm2totp_deleteKey_nv(0, NULL);
-    chkrc(rc, exit(1));
+    rc = tpm2totp_deleteKey_nv(0, tcti_context);
+    chkrc(rc, goto err);
 
 /***********/
 
     free(keyBlob);
     free(secret);
+    tcti_finalize();
     return 0;
+
+err:
+    free(keyBlob);
+    free(secret);
+    tcti_finalize();
+    return 1;
 }

--- a/test/libtpm2-totp.sh
+++ b/test/libtpm2-totp.sh
@@ -16,53 +16,15 @@ set -x
 export TSS2_LOG=all+none
 #export TSS2_LOG=esys+trace
 
-TPMSIM=tpm_server
-
 PWD1="abc"
-
-function prereq()
-{
-    if [ -f NVChip ]; then
-        echo "There is a leftover file NVChip in the test directory."
-        return 99 #ERROR
-    fi
-
-    if killall -0 $(basename $TPMSIM); then
-        echo "There is already a tpm_simulator running."
-        return 99 #ERROR
-    fi
-
-    trap "cleanup" EXIT
-}
-
-function prepare()
-{
-    $TPMSIM &
-}
-
-function cleanup()
-{
-    killall $(basename $TPMSIM) || true
-    rm NVChip || true
-    echo .
-}
 
 function error()
 {
     echo "FAILED"
 }
 
-function fail()
-{
-    return 1
-}
-
 trap "error" ERR
 
-prereq
-
-prepare
-
-./libtpm2-totp
+libtpm2-totp
 
 

--- a/test/sh_log_compiler.sh
+++ b/test/sh_log_compiler.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+export LANG=C
+export PATH="$PWD:$PATH"
+
+test_script="$(realpath "$1")"
+
+tmp_dir="$(mktemp --directory)"
+echo "Switching to temporary directory $tmp_dir"
+cd "$tmp_dir"
+
+for attempt in $(seq 9 -1 0); do
+    tpm_server_port="$(shuf --input-range 1024-65534 --head-count 1)"
+    echo "Starting simulator on port $tpm_server_port"
+    tpm_server -port "$tpm_server_port" &
+    tpm_server_pid="$!"
+    sleep 1
+
+    if ( ss --listening --tcp --ipv4 --processes | grep "$tpm_server_pid" | grep --quiet "$tpm_server_port" &&
+         ss --listening --tcp --ipv4 --processes | grep "$tpm_server_pid" | grep --quiet "$(( tpm_server_port + 1 ))" )
+    then
+        echo "Simulator with PID $tpm_server_pid started successfully"
+        break
+    else
+        echo "Failed to start simulator, the port might be in use"
+        kill "$tpm_server_pid"
+
+        if [ "$attempt" -eq 0 ]; then
+            echo 'ERROR: Reached maximum number of tries to start simulator, giving up'
+            exit 99
+        fi
+    fi
+done
+
+export TPM2TOTP_TCTI="libtss2-tcti-mssim.so.0:port=$tpm_server_port"
+export TPM2TOOLS_TCTI="$TPM2TOTP_TCTI"
+
+tpm2_startup --clear
+
+echo "Starting $test_script"
+"$test_script"
+test_status="$?"
+
+kill "$tpm_server_pid"
+rm -rf "$tmp_dir"
+
+exit "$test_status"

--- a/test/tpm2-totp.sh
+++ b/test/tpm2-totp.sh
@@ -16,81 +16,43 @@ set -x
 export TSS2_LOG=all+none
 #export TSS2_LOG=esys+trace
 
-TPMSIM=tpm_server
-
 PWD1="abc"
-
-function prereq()
-{
-    if [ -f NVChip ]; then
-        echo "There is a leftover file NVChip in the test directory."
-        return 99 #ERROR
-    fi
-
-    if killall -0 $(basename $TPMSIM); then
-        echo "There is already a tpm_simulator running."
-        return 99 #ERROR
-    fi
-
-    trap "cleanup" EXIT
-}
-
-function prepare()
-{
-    $TPMSIM &
-}
-
-function cleanup()
-{
-    killall $(basename $TPMSIM) || true
-    rm NVChip || true
-    echo .
-}
 
 function error()
 {
     echo "FAILED"
 }
 
-function fail()
-{
-    return 1
-}
-
 trap "error" ERR
 
-prereq
-
-prepare
-
-./tpm2-totp -P abc -p 0,1,2,3,4,5,6 -b SHA1,SHA256 generate
+tpm2-totp -P abc -p 0,1,2,3,4,5,6 -b SHA1,SHA256 generate
 
 # Changing an unselected PCR bank should not affect the TOTP calculation
-tpm2_pcrextend -T mssim 0:sha384=000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+tpm2_pcrextend 0:sha384=000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 
-./tpm2-totp -t calculate
+tpm2-totp -t calculate
 
-tpm2_pcrextend -T mssim 1:sha1=0000000000000000000000000000000000000000
+tpm2_pcrextend 1:sha1=0000000000000000000000000000000000000000
 
-if ./tpm2-totp -t calculate; then
+if tpm2-totp -t calculate; then
     echo "The TOTP was calculated despite a changed PCR state!"
     exit 1
 fi
 
-./tpm2-totp -P abc recover
+tpm2-totp -P abc recover
 
-./tpm2-totp -P abc -p 0,1,2,3,4,5,6 -b SHA1,SHA256 reseal
+tpm2-totp -P abc -p 0,1,2,3,4,5,6 -b SHA1,SHA256 reseal
 
 # Changing an unselected PCR bank should not affect the TOTP calculation
-tpm2_pcrextend -T mssim 0:sha384=000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+tpm2_pcrextend 0:sha384=000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 
-./tpm2-totp calculate
+tpm2-totp calculate
 
-tpm2_pcrextend -T mssim 1:sha1=0000000000000000000000000000000000000000
+tpm2_pcrextend 1:sha1=0000000000000000000000000000000000000000
 
-if ./tpm2-totp calculate; then
+if tpm2-totp calculate; then
     echo "The TOTP was calculated despite a changed PCR state!"
     exit 1
 fi
 
-./tpm2-totp clean
+tpm2-totp clean


### PR DESCRIPTION
This PR makes allows configuring the TCTI to be used with
- an additional `TSS2_TCTI_CONTEXT` argument (can be `NULL`) for the library functions and
- the new `-T`/`--tcti` option or the environment variable `TPM2TOTP_TCTI` for the tpm2-totp command.

The syntax and the implementation for the command option/environment variable follow the implementations in tpm2-tools (https://github.com/tpm2-software/tpm2-tools/pull/765, [`tpm2_options.c`](https://github.com/tpm2-software/tpm2-tools/blob/35fd340c9b29e880284a2535b210e8b97048cddc/lib/tpm2_options.c#L173) and [`tpm2_tcti_ldr.c`](https://github.com/tpm2-software/tpm2-tools/blob/35fd340c9b29e880284a2535b210e8b97048cddc/lib/tpm2_tcti_ldr.c#L80)) and tpm2-tss-engine (https://github.com/tpm2-software/tpm2-tss-engine/pull/62, [`tpm2-tss-engine-tcti.c`](https://github.com/tpm2-software/tpm2-tss-engine/blob/master/src/tpm2-tss-engine-tcti.c)).

Using these configuration options, we can force the tests to use the TPM simulator, enabling the possibility to run the tests (in parallel) on systems with existing hardware TPMs. The implementation is adapted from tpm2-tss-engine (https://github.com/tpm2-software/tpm2-tss-engine/pull/107, [`sh_log_compiler.sh`](https://github.com/tpm2-software/tpm2-tss-engine/blob/master/test/sh_log_compiler.sh)).

Closes #7.