### PR TITLE
dist: add mkinitcpio hooks

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -116,3 +116,9 @@ EXTRA_DIST += \
     man/tpm2-totp.1.md
 CLEANFILES += \
     $(man1_MANS)
+
+if HAVE_MKINITCPIO
+initcpio_install_DATA = dist/initcpio/install/tpm2-totp
+initcpio_hooks_DATA = dist/initcpio/hooks/tpm2-totp
+endif # HAVE_MKINITCPIO
+EXTRA_DIST += dist/initcpio/install/tpm2-totp dist/initcpio/hooks/tpm2-totp

--- a/configure.ac
+++ b/configure.ac
@@ -103,10 +103,22 @@ AS_IF([test "x$enable_integration" != xno],
              [AC_MSG_ERROR([Integration tests require the ss executable])])
       ])
 
+AC_ARG_WITH([mkinitcpiodir],
+            AS_HELP_STRING([--with-mkinitcpiodir=DIR], [directory for mkinitcpio hooks]))
+AC_CHECK_PROG([mkinitcpio], [mkinitcpio], [yes])
+AS_IF([test "x$mkinitcpio" = xyes -a -z "$with_mkinitcpiodir"],
+      [with_mkinitcpiodir=$sysconfdir/initcpio])
+AS_IF([test "x$with_mkinitcpiodir" != xno],
+      [AC_SUBST([initcpio_installdir], [$with_mkinitcpiodir/install])
+       AC_SUBST([initcpio_hooksdir], [$with_mkinitcpiodir/hooks])
+      ])
+AM_CONDITIONAL(HAVE_MKINITCPIO, [test -n "$with_mkinitcpiodir" -a "x$with_mkinitcpiodir" != xno])
+
 AC_OUTPUT
 
 AC_MSG_RESULT([
 $PACKAGE_NAME $VERSION
     man-pages:  $PANDOC
+    mkinitcpio: $with_mkinitcpiodir
 ])
     

--- a/dist/initcpio/hooks/tpm2-totp
+++ b/dist/initcpio/hooks/tpm2-totp
@@ -1,0 +1,13 @@
+#!/usr/bin/ash
+
+run_hook() {
+    echo 'Verify the TOTP (press any key to continue):'
+    TSS2_LOG=esys+error tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} --time calculate
+    echo
+    while ! read -n 1 -r -s -t 10; do
+        TSS2_LOG=esys+error tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} --time calculate
+        echo
+    done
+}
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/dist/initcpio/install/tpm2-totp
+++ b/dist/initcpio/install/tpm2-totp
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+build() {
+    local mod
+
+    if [[ $TPM_MODULES ]]; then
+        for mod in $TPM_MODULES; do
+            add_module "$mod"
+        done
+    else
+        add_all_modules /tpm/
+    fi
+
+    add_binary tpm2-totp
+
+    add_runscript
+}
+
+help() {
+    cat <<HELPEOF
+This hook displays a time-based one-time password (TOTP) sealed to a Trusted
+Platform Module (TPM) to ensure that the boot process has not been tampered
+with. To set this up, a secret needs to be generated first and sealed to the
+TPM using
+
+tpm2-totp generate
+
+This stores the secret in the TPM and displays it to the user so that it can
+be recorded on a different device (e.g. a TOTP app). When the hook is run, the
+TOTP is calculated and displayed together with the current time so that it can
+be compared with the output of the second device. This will only be successful
+and show a matching output if the boot process has not changed (new UEFI
+firmware, different boot loader, ...).
+
+When using a custom NV index with the '--nvindex index' option of tpm2-totp,
+this index needs to be specified as 'tpm2_totp_nvindex=index' on the kernel
+command line.
+
+Note that calculating the TOTP requires some entropy, which might be scarce
+directly after startup. If the boot process appears to be stuck, it might help
+to press some random keys to gather more entropy. A better alternative on modern
+processors is to enable the use of the hardware random number generator (RNG)
+by adding
+
+random.trust_cpu=on
+
+to the kernel command line.
+HELPEOF
+}
+
+# vim: set ft=sh ts=4 sw=4 et:


### PR DESCRIPTION
Add hooks for [mkinitcpio](https://wiki.archlinux.org/index.php/Mkinitcpio), the tool used by Arch Linux to generate initial ramdisks. The files are upstreamed from the [tpm2-totp Arch User Repository (AUR) package](https://aur.archlinux.org/packages/tpm2-totp). They are only installed if `mkinitcpio` is found on the system or `--with-mkinitcpiodir` is set explicitly to the initcpio hooks directory (`/etc/initcpio` for user files or `/usr/lib/initcpio` for packages).