### PR TITLE
Add plymouth integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ config.sub
 configure
 depcomp
 dist/*.pc
+dist/initcpio/install/plymouth-tpm2-totp
 install-sh
 libtool
 ltmain.sh

--- a/.gitignore
+++ b/.gitignore
@@ -40,5 +40,6 @@ man/man7/
 *~
 /libtpm2-totp
 /tpm2-totp
+/plymouth-tpm2-totp
 /AUTHORS
 /*.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,9 @@ addons:
     - liboath-dev
     - libqrencode-dev
     - pandoc
+    - libplymouth-dev
+    - plymouth
+    - fakeroot
 
 install:
   - git clean -xdf
@@ -96,7 +99,7 @@ script:
     else
       export SCAN_PREFIX="scan-build --status-bugs"
     fi
-  - $SCAN_PREFIX ../configure $CONFIGURE_OPTIONS --enable-integration
+  - $SCAN_PREFIX ../configure $CONFIGURE_OPTIONS --enable-integration --enable-plymouth
   - $SCAN_PREFIX make -j$(nproc)
   - make -j$(nproc) check
   - cat test-suite.log

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,10 +64,15 @@ TESTS =
 
 if INTEGRATION
 TESTS += $(TESTS_SHELL)
+
+if PLYMOUTH
+TESTS += $(TESTS_PLYMOUTH)
+endif # PLYMOUTH
 endif #INTEGRATION
 TESTS_SHELL = test/libtpm2-totp.sh \
               test/tpm2-totp.sh
-EXTRA_DIST += $(TESTS_SHELL)
+TESTS_PLYMOUTH = test/plymouth-tpm2-totp.sh
+EXTRA_DIST += $(TESTS_SHELL) $(TESTS_PLYMOUTH)
 TEST_EXTENSIONS = .sh
 SH_LOG_COMPILER = $(srcdir)/test/sh_log_compiler.sh
 EXTRA_DIST += $(SH_LOG_COMPILER)

--- a/Makefile.am
+++ b/Makefile.am
@@ -134,5 +134,12 @@ CLEANFILES += \
 if HAVE_MKINITCPIO
 initcpio_install_DATA = dist/initcpio/install/tpm2-totp
 initcpio_hooks_DATA = dist/initcpio/hooks/tpm2-totp
+if PLYMOUTH
+initcpio_install_DATA += dist/initcpio/install/plymouth-tpm2-totp
+initcpio_hooks_DATA += dist/initcpio/hooks/plymouth-tpm2-totp
+endif # PLYMOUTH
 endif # HAVE_MKINITCPIO
-EXTRA_DIST += dist/initcpio/install/tpm2-totp dist/initcpio/hooks/tpm2-totp
+EXTRA_DIST += \
+	dist/initcpio/install/tpm2-totp \
+	dist/initcpio/hooks/tpm2-totp \
+	dist/initcpio/hooks/plymouth-tpm2-totp

--- a/Makefile.am
+++ b/Makefile.am
@@ -12,6 +12,7 @@ AM_LDADD        = $(TSS2_ESYS_LIBS) $(QRENCODE_LIBS) -ldl
 
 # Initialize empty variables to be extended throughout
 bin_PROGRAMS =
+libexec_PROGRAMS =
 noinst_PROGRAMS =
 check_PROGRAMS =
 include_HEADERS =
@@ -49,6 +50,14 @@ bin_PROGRAMS += tpm2-totp
 tpm2_totp_SOURCES = src/tpm2-totp.c src/tpm2-totp-tcti.c src/tpm2-totp-tcti.h
 tpm2_totp_LDADD = $(AM_LDADD) libtpm2-totp.la
 tpm2_totp_LDFLAGS = $(AM_LDFLAGS)
+
+if PLYMOUTH
+libexec_PROGRAMS += plymouth-tpm2-totp
+plymouth_tpm2_totp_SOURCES = src/plymouth-tpm2-totp.c src/tpm2-totp-tcti.c src/tpm2-totp-tcti.h
+plymouth_tpm2_totp_CFLAGS = $(AM_CFLAGS) $(PLY_BOOT_CLIENT_CFLAGS)
+plymouth_tpm2_totp_LDADD = $(AM_LDADD) $(PLY_BOOT_CLIENT_LIBS) libtpm2-totp.la
+plymouth_tpm2_totp_LDFLAGS = $(AM_LDFLAGS) $(PLY_BOOT_CLIENT_LDFLAGS)
+endif # PLYMOUTH
 
 ### Tests ###
 TESTS =

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,19 @@ AS_IF([test -z "$PANDOC"],
 AM_CONDITIONAL([HAVE_PANDOC],[test -n "$PANDOC"])
 AM_CONDITIONAL([HAVE_MAN_PAGES],[test -d "${srcdir}/man/man1" -o -n "$PANDOC"])
 
+AC_ARG_ENABLE([plymouth],
+              AS_HELP_STRING([--disable-plymouth], [Disable plymouth support]))
+AS_IF([test "x$enable_plymouth" != "xno"],
+      [PKG_CHECK_MODULES([PLY_BOOT_CLIENT], [ply-boot-client],
+                         [have_plymouth=yes], [have_plymouth=no])],
+      [have_plymouth=no])
+AM_CONDITIONAL([PLYMOUTH], [test "x$have_plymouth" = "xyes"])
+AS_IF([test "x$have_plymouth" = "xyes"],,
+      [AS_IF([test "x$enable_plymouth" = "xyes"],
+             [AC_MSG_ERROR([plymouth requested but not found])
+      ])
+])
+
 AC_ARG_ENABLE([integration],
             [AS_HELP_STRING([--enable-integration],
                             [build integration tests against TPM])],,
@@ -120,5 +133,6 @@ AC_MSG_RESULT([
 $PACKAGE_NAME $VERSION
     man-pages:  $PANDOC
     mkinitcpio: $with_mkinitcpiodir
+    plymouth:   $have_plymouth
 ])
     

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,10 @@ LT_INIT()
 
 PKG_INSTALLDIR()
 
-AC_CONFIG_FILES([Makefile dist/tpm2-totp.pc])
+AX_RECURSIVE_EVAL([$libexecdir], [LIBEXECDIR])
+AC_SUBST([LIBEXECDIR])
+
+AC_CONFIG_FILES([Makefile dist/tpm2-totp.pc dist/initcpio/install/plymouth-tpm2-totp])
 
 AX_ADD_COMPILER_FLAG([-std=c99])
 AX_ADD_COMPILER_FLAG([-Wall])

--- a/configure.ac
+++ b/configure.ac
@@ -114,6 +114,21 @@ AS_IF([test "x$enable_integration" != xno],
        AC_CHECK_PROG([ss], [ss], [yes])
        AS_IF([test "x$ss" != xyes],
              [AC_MSG_ERROR([Integration tests require the ss executable])])
+
+       AS_IF([test "x$have_plymouth" = "xyes"],
+             [AC_CHECK_PROG([plymouthd], [plymouthd], [yes])
+              AS_IF([test "x$plymouthd" != xyes],
+                    [AC_MSG_ERROR([Integration tests require the plymouthd executable])])
+              AC_CHECK_PROG([fakeroot], [fakeroot], [yes])
+              AS_IF([test "x$fakeroot" != xyes],
+                    [AC_MSG_WARN([Executable fakeroot not found, integration tests must be run as root])])
+              AC_CHECK_PROG([pgrep], [pgrep], [yes])
+              AS_IF([test "x$pgrep" != xyes],
+                    [AC_MSG_ERROR([Integration tests require the pgrep executable])])
+              AC_CHECK_PROG([timeout], [timeout], [yes])
+              AS_IF([test "x$timeout" != xyes],
+                    [AC_MSG_ERROR([Integration tests require the timeout executable])])
+             ])
       ])
 
 AC_ARG_WITH([mkinitcpiodir],

--- a/dist/initcpio/hooks/plymouth-tpm2-totp
+++ b/dist/initcpio/hooks/plymouth-tpm2-totp
@@ -1,0 +1,7 @@
+#!/usr/bin/ash
+
+run_hook() {
+    TSS2_LOG=esys+error plymouth-tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} &
+}
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/dist/initcpio/install/plymouth-tpm2-totp.in
+++ b/dist/initcpio/install/plymouth-tpm2-totp.in
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+build() {
+    local mod
+
+    if [[ $TPM_MODULES ]]; then
+        for mod in $TPM_MODULES; do
+            add_module "$mod"
+        done
+    else
+        add_all_modules /tpm/
+    fi
+
+    add_binary /usr/lib/plymouth/label.so
+    add_file /usr/share/fonts/TTF/DejaVuSans.ttf
+
+    add_binary @LIBEXECDIR@/plymouth-tpm2-totp /usr/bin/plymouth-tpm2-totp
+
+    add_runscript
+}
+
+help() {
+    cat <<HELPEOF
+This hook uses plymouth to display a time-based one-time password (TOTP) sealed
+to a Trusted Platform Module (TPM) to ensure that the boot process has not been
+tampered with. To set this up, a secret needs to be generated first and sealed
+to the TPM using
+
+tpm2-totp generate
+
+This stores the secret in the TPM and displays it to the user so that it can
+be recorded on a different device (e.g. a TOTP app). When the hook is run, the
+TOTP is calculated and displayed using plymouth so that it can be compared with
+the output of the second device. This will only be successful and show a
+matching output if the boot process has not changed (new UEFI firmware,
+different boot loader, ...).
+
+When using a custom NV index with the '--nvindex index' option of tpm2-totp,
+this index needs to be specified as 'tpm2_totp_nvindex=index' on the kernel
+command line.
+
+Note that calculating the TOTP requires some entropy, which might be scarce
+directly after startup. If the boot process appears to be stuck, it might help
+to press some random keys to gather more entropy. A better alternative on modern
+processors is to enable the use of the hardware random number generator (RNG)
+by adding
+
+random.trust_cpu=on
+
+to the kernel command line.
+HELPEOF
+}
+
+# vim: set ft=sh ts=4 sw=4 et:

--- a/src/plymouth-tpm2-totp.c
+++ b/src/plymouth-tpm2-totp.c
@@ -1,0 +1,231 @@
+/* SPDX-License-Identifier: BSD-3-Clause */
+/*******************************************************************************
+ * Copyright 2019, Jonas Witschel
+ * All rights reserved.
+ *******************************************************************************/
+
+#include <tpm2-totp.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <getopt.h>
+#include <ply-boot-client.h>
+
+#include "tpm2-totp-tcti.h"
+
+#define VERB(...) if (opt.verbose) fprintf(stderr, __VA_ARGS__)
+#define ERR(...) fprintf(stderr, __VA_ARGS__)
+
+#define chkrc(rc, cmd) if (rc != TSS2_RC_SUCCESS) {\
+    ERR("ERROR in %s (%s:%i): 0x%08x\n", __func__, __FILE__, __LINE__, rc); cmd; }
+
+typedef struct {
+    ply_boot_client_t *boot_client;
+    ply_event_loop_t *event_loop;
+    TSS2_TCTI_CONTEXT *tcti_context;
+    uint8_t *key_blob;
+    size_t key_blob_size;
+} state_t;
+
+char *help =
+    "Usage: [options]\n"
+    "Options:\n"
+    "    -h, --help      print help\n"
+    "    -N, --nvindex   TPM NV index to store data (default: 0x018094AF)\n"
+    "    -t, --time      Show the time used for calculation\n"
+    "    -T, --tcti      TCTI to use\n"
+    "    -v, --verbose   print verbose messages\n"
+    "\n";
+
+static const char *optstr = "hN:tT:v";
+
+static const struct option long_options[] = {
+    {"help",     no_argument,       0, 'h'},
+    {"nvindex",  required_argument, 0, 'N'},
+    {"time",     no_argument,       0, 't'},
+    {"tcti",     required_argument, 0, 'T'},
+    {"verbose",  no_argument,       0, 'v'},
+    {0,          0,                 0,  0 }
+};
+
+static struct opt {
+    int nvindex;
+    int time;
+    char *tcti;
+    int verbose;
+} opt;
+
+/** Parse and set command line options.
+ *
+ * This function parses the command line options and sets the appropriate values
+ * in the opt struct.
+ * @param argc The argument count.
+ * @param argv The arguments.
+ * @retval 0 on success
+ * @retval 1 on failure
+ */
+int
+parse_opts(int argc, char **argv)
+{
+    /* set the default values */
+    opt.nvindex = 0;
+    opt.tcti = NULL;
+    opt.time = 0;
+    opt.verbose = 0;
+
+    /* parse the options */
+    int c;
+    int opt_idx = 0;
+    while (-1 != (c = getopt_long(argc, argv, optstr,
+                                  long_options, &opt_idx))) {
+        switch(c) {
+        case 'h':
+            printf("%s", help);
+            exit(0);
+        case 'N':
+            if (sscanf(optarg, "0x%x", &opt.nvindex) != 1
+                && sscanf(optarg, "%i", &opt.nvindex) != 1) {
+                ERR("Error parsing nvindex.\n");
+                return -1;
+            }
+            break;
+        case 't':
+            opt.time = 1;
+            break;
+        case 'T':
+            opt.tcti = optarg;
+            break;
+        case 'v':
+            opt.verbose = 1;
+            break;
+        default:
+            ERR("Unknown option at index %i.\n\n", opt_idx);
+            ERR("%s", help);
+            return -1;
+        }
+    }
+
+    if (optind < argc) {
+        ERR("Unknown argument provided.\n\n");
+        ERR("%s", help);
+        return -1;
+    }
+    return 0;
+}
+
+/** Exit the plymouth event loop after plymouth quits.
+ *
+ * This function is called when plymouth quits after boot and exits the main
+ * event loop so that the program quits.
+ * @param event_loop The plymouth event loop.
+ * @param boot_client The plymouth boot client.
+ */
+void
+on_disconnect(void *event_loop, ply_boot_client_t *boot_client __attribute__((unused)))
+{
+    ply_event_loop_exit(event_loop, 0);
+}
+
+/** Display the TOTP.
+ *
+ * This function calculates and displays the TOTP using plymouth. If the
+ * calcuation is successful, the function is rescheduled in the plymouth event
+ * loop to run after the next full 30 seconds, otherwise the event loop is
+ * stopped with a non-zero return code.
+ * @param state a struct containing the boot client, TCTI context and key.
+ * @param event_loop The plymouth event loop.
+ */
+void
+display_totp(state_t *state, ply_event_loop_t *event_loop)
+{
+    int rc;
+    uint64_t totp;
+    time_t now;
+    char timestr[30] = "";
+    char totpstr[40] = "";
+
+    rc = tpm2totp_calculate(state->key_blob, state->key_blob_size,
+                            state->tcti_context, &now, &totp);
+
+    if (rc == TSS2_RC_SUCCESS) {
+        if (opt.time) {
+            if (strftime(timestr, sizeof(timestr)-1, "%F %T: ", localtime(&now)) == 0) {
+                timestr[0] = '\0';
+            }
+        }
+        snprintf(totpstr, sizeof(totpstr)-1, "%s%06" PRIu64, timestr, totp);
+
+        ply_boot_client_tell_daemon_to_display_message(state->boot_client, totpstr,
+                                                       NULL, NULL, NULL);
+
+        ply_event_loop_watch_for_timeout(event_loop, 30-(now % 30),
+                                         (ply_event_loop_timeout_handler_t) display_totp,
+                                         state);
+    } else {
+        ERR("Couldn't calculate TOTP.\n");
+        ply_boot_client_tell_daemon_to_display_message(state->boot_client,
+                                                       "TPM failure", NULL, NULL, NULL);
+        ply_event_loop_exit(event_loop, 1);
+    }
+}
+
+/** Main function
+ *
+ * This function connects to plymouth, loads the key from the TPM and calls
+ * the function to display the TOTP.
+ * @param argc The argument count.
+ * @param argv The arguments.
+ * @retval 0 on success
+ * @retval 1 on failure
+ */
+int
+main(int argc, char **argv)
+{
+    state_t state = { 0, };
+    int rc;
+
+    if (parse_opts(argc, argv) != 0) {
+        return 1;
+    }
+
+    state.event_loop = ply_event_loop_new();
+    state.boot_client = ply_boot_client_new();
+
+    if (!ply_boot_client_connect(state.boot_client, on_disconnect, state.event_loop)) {
+        ERR("plymouth daemon not running.\n");
+        goto err;
+    }
+
+    ply_boot_client_attach_to_event_loop(state.boot_client, state.event_loop);
+
+    if (tcti_init(opt.tcti, &state.tcti_context) != 0) {
+        ERR("Couldn't initialize TCTI.\n");
+        goto err;
+    }
+
+    rc = tpm2totp_loadKey_nv(opt.nvindex, state.tcti_context, &state.key_blob, &state.key_blob_size);
+    chkrc(rc, goto err);
+
+    display_totp(&state, state.event_loop);
+
+    rc = ply_event_loop_run(state.event_loop);
+
+    free(state.key_blob);
+    ply_boot_client_free(state.boot_client);
+    ply_event_loop_free(state.event_loop);
+    tcti_finalize();
+    return rc;
+
+err:
+    /* The event loop needs to be run once so that it can be freed cleanly */
+    ply_event_loop_exit(state.event_loop, 1);
+    ply_event_loop_run(state.event_loop);
+
+    free(state.key_blob);
+    ply_boot_client_free(state.boot_client);
+    ply_event_loop_free(state.event_loop);
+    tcti_finalize();
+    return 1;
+}

--- a/test/plymouth-tpm2-totp.sh
+++ b/test/plymouth-tpm2-totp.sh
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2019 Jonas Witschel
+# All rights reserved.
+#!/bin/bash
+
+set -eufx
+
+success_or_timeout() {
+    # 124 is the exit status GNU timeout returns when the timeout is reached
+    [ "$1" -eq 0 ] || [ "$1" -eq 124 ]
+    return $?
+}
+
+cleanup() {
+   kill "$plymouth_tpm2_totp_pid" || true
+   kill "$plymouthd_pid" || true
+}
+
+plymouthd_pid=''
+plymouth_tpm2_totp_pid=''
+trap "cleanup" EXIT
+
+if pgrep plymouthd; then
+   echo "ERROR: plymouthd is already running."
+   exit 99
+fi
+
+plymouth-tpm2-totp --help
+
+exit_status=0
+timeout 10s plymouth-tpm2-totp || exit_status=$?
+if success_or_timeout "$exit_status"; then
+   echo "plymouth-tpm2-totp should fail when plymouthd is not running."
+   exit 1
+fi
+
+if [ "$EUID" -eq 0 ]; then
+    plymouthd --no-daemon &
+else
+    # plymouthd usually needs root access in order to display the splash screen.
+    # Since we are only interested in the messaging infrastructure, attempt to
+    # start plymouthd with fakeroot.
+    fakeroot plymouthd --no-daemon &
+fi
+sleep 1
+
+# We need the PID of plymouthd, not the fakeroot PID, so we cannot use $!
+plymouthd_pid="$(pgrep plymouthd)"
+if [ -z "$plymouthd_pid" ]; then
+    echo "ERROR: Failed to start plymouthd."
+    exit 99
+fi
+
+tpm2-totp --banks SHA256 --pcrs 0 --nvindex 0x018094AF --password abc generate
+
+tpm2_pcrextend 0:sha256=0000000000000000000000000000000000000000000000000000000000000000
+exit_status=0
+timeout 10s plymouth-tpm2-totp --nvindex 0x018094AF || exit_status=$?
+if success_or_timeout "$exit_status"; then
+   echo "plymouth-tpm2-totp should fail when the PCR state is changed."
+   exit 1
+fi
+
+tpm2-totp --nvindex 0x018094AF --password abc reseal
+
+plymouth-tpm2-totp --nvindex 0x018094AF --time &
+plymouth_tpm2_totp_pid=$!
+
+# Wait for the TOTP to refresh after 30 seconds
+sleep 40
+
+kill "$plymouthd_pid"
+
+# Give plymouth-tpm2-totp some time to quit
+timeout 10s tail --pid "$plymouth_tpm2_totp_pid" --follow /dev/null
+
+# plymouthd-tpm2-totp should exit successfully after plymouthd has quit
+wait "$plymouth_tpm2_totp_pid"


### PR DESCRIPTION
This PR adds a binary `plymouth-tpm2-totp` that calculates the TOTP and displays it as a [plymouth](https://www.freedesktop.org/wiki/Software/Plymouth) message. Depending on the theme, this will look somewhat like this (the password prompt is for the disk encryption):

![Plymouth boot splash with TOTP and disk encryption password prompt](https://i.imgur.com/eSErMnQ.gif)

The application is intended to be installed and run in the background in the initial ramdisk and will automatically exit when plymouth is stopped after booting is complete.

One plymouth message with the TOTP is displayed when the application is started, after that a new message is displayed after each full 30 seconds when the TOTP changes. If there are other plymouth messages, these will overwrite the TOTP. Since this usually only happens if there are errors during boot, the user will probably want to see these instead of the TOTP.

There are also some integration tests with the plymouth daemon. They check whether `plymouth-tpm2-totp` is successfully able to send messages to the daemon and if it exits with the correct status if plymouth quits or the TOTP calculation fails.

Also included are mkinitpio hooks to add the binary to the initial ramdisk and start it in the background. They replace the already existing hooks on systems with plymouth installed.

I have successfully been testing this PR on my own computer for the last week.

Closes #5.