### PR TITLE
test: add integration test for mkinitcpio hook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ compiler:
 
 dist: xenial
 
-cache: ccache
-
 env:
   matrix:
   - OPENSSL_BRANCH=OpenSSL_1_0_2-stable

--- a/Makefile.am
+++ b/Makefile.am
@@ -65,14 +65,19 @@ TESTS =
 if INTEGRATION
 TESTS += $(TESTS_SHELL)
 
+if HAVE_MKINITCPIO
+TESTS += $(TESTS_MKINITCPIO)
+endif # HAVE_MKINITCPIO
+
 if PLYMOUTH
 TESTS += $(TESTS_PLYMOUTH)
 endif # PLYMOUTH
 endif #INTEGRATION
 TESTS_SHELL = test/libtpm2-totp.sh \
               test/tpm2-totp.sh
+TESTS_MKINITCPIO = test/mkinitcpio-tpm2-totp.sh
 TESTS_PLYMOUTH = test/plymouth-tpm2-totp.sh
-EXTRA_DIST += $(TESTS_SHELL) $(TESTS_PLYMOUTH)
+EXTRA_DIST += $(TESTS_SHELL) $(TESTS_MKINITCPIO) $(TESTS_PLYMOUTH)
 TEST_EXTENSIONS = .sh
 SH_LOG_COMPILER = $(srcdir)/test/sh_log_compiler.sh
 EXTRA_DIST += $(SH_LOG_COMPILER)

--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,17 @@ AS_IF([test -z "$PANDOC"],
 AM_CONDITIONAL([HAVE_PANDOC],[test -n "$PANDOC"])
 AM_CONDITIONAL([HAVE_MAN_PAGES],[test -d "${srcdir}/man/man1" -o -n "$PANDOC"])
 
+AC_ARG_WITH([mkinitcpiodir],
+            AS_HELP_STRING([--with-mkinitcpiodir=DIR], [directory for mkinitcpio hooks]))
+AC_CHECK_PROG([mkinitcpio], [mkinitcpio], [yes])
+AS_IF([test "x$mkinitcpio" = xyes -a -z "$with_mkinitcpiodir"],
+      [with_mkinitcpiodir=$sysconfdir/initcpio])
+AS_IF([test "x$with_mkinitcpiodir" != xno],
+      [AC_SUBST([initcpio_installdir], [$with_mkinitcpiodir/install])
+       AC_SUBST([initcpio_hooksdir], [$with_mkinitcpiodir/hooks])
+      ])
+AM_CONDITIONAL(HAVE_MKINITCPIO, [test -n "$with_mkinitcpiodir" -a "x$with_mkinitcpiodir" != xno])
+
 AC_ARG_ENABLE([plymouth],
               AS_HELP_STRING([--disable-plymouth], [Disable plymouth support]))
 AS_IF([test "x$enable_plymouth" != "xno"],
@@ -132,18 +143,12 @@ AS_IF([test "x$enable_integration" != xno],
               AS_IF([test "x$timeout" != xyes],
                     [AC_MSG_ERROR([Integration tests require the timeout executable])])
              ])
-      ])
 
-AC_ARG_WITH([mkinitcpiodir],
-            AS_HELP_STRING([--with-mkinitcpiodir=DIR], [directory for mkinitcpio hooks]))
-AC_CHECK_PROG([mkinitcpio], [mkinitcpio], [yes])
-AS_IF([test "x$mkinitcpio" = xyes -a -z "$with_mkinitcpiodir"],
-      [with_mkinitcpiodir=$sysconfdir/initcpio])
-AS_IF([test "x$with_mkinitcpiodir" != xno],
-      [AC_SUBST([initcpio_installdir], [$with_mkinitcpiodir/install])
-       AC_SUBST([initcpio_hooksdir], [$with_mkinitcpiodir/hooks])
+       AM_COND_IF([HAVE_MKINITCPIO],
+                  [AS_IF([test "x$mkinitcpio" != xyes],
+                         [AC_MSG_ERROR([Integration tests require mkinitcpio to be installed])])
+                  ])
       ])
-AM_CONDITIONAL(HAVE_MKINITCPIO, [test -n "$with_mkinitcpiodir" -a "x$with_mkinitcpiodir" != xno])
 
 AC_OUTPUT
 

--- a/test/libtpm2-totp.sh
+++ b/test/libtpm2-totp.sh
@@ -1,7 +1,7 @@
+#!/bin/bash
 # SPDX-License-Identifier: BSD-3
 # Copyright (c) 2018 Fraunhofer SIT
 # All rights reserved.
-#!/bin/bash
 
 set -eufx
 

--- a/test/mkinitcpio-tpm2-totp.sh
+++ b/test/mkinitcpio-tpm2-totp.sh
@@ -1,0 +1,19 @@
+#!/usr/lib/initcpio/busybox ash
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2019 Jonas Witschel
+# All rights reserved.
+
+set -eufx
+
+tpm2-totp generate
+
+. "$(dirname "$(realpath "$0")")"/../dist/initcpio/hooks/tpm2-totp
+
+printf 'a' | run_hook | grep -Pz 'Verify the TOTP \(press any key to continue\):\n\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}: \d{6}' &
+grep_pid=$!
+
+# If the read call in run_hook fails, e.g. because some of the non-POSIX options
+# are not recognised, we are stuck in an endless loop. Wait at most 10 seconds
+# for the loop to finish, and check to exit status of grep.
+timeout 10s tail --pid "$grep_pid" --follow /dev/null
+wait "$grep_pid"

--- a/test/sh_log_compiler.sh
+++ b/test/sh_log_compiler.sh
@@ -1,7 +1,7 @@
+#!/bin/bash
 # SPDX-License-Identifier: BSD-3
 # Copyright (c) 2019 Jonas Witschel
 # All rights reserved.
-#!/bin/bash
 
 export LANG=C
 export PATH="$PWD:$PATH"

--- a/test/tpm2-totp.sh
+++ b/test/tpm2-totp.sh
@@ -1,7 +1,7 @@
+#!/bin/bash
 # SPDX-License-Identifier: BSD-3
 # Copyright (c) 2018 Fraunhofer SIT
 # All rights reserved.
-#!/bin/bash
 
 set -eufx
 


### PR DESCRIPTION
As suggested in https://github.com/tpm2-software/tpm2-totp/pull/21#issuecomment-489558311, add a test for the mkinitcpio run hook to verify that all non-POSIX options to `read` are understood correctly. We want to do this with the BusyBox shell `/usr/lib/initcpio/busybox ash` used in initcpio ramdisks, so we need to have mkinitcpio installed for this test.

Also move the shebang to the first line in the other integration tests so that it is recognised by the kernel and we don't run into problems on systems where the default shell isn't Bash.