### PR TITLE
Fix SPDX license identifier

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3
+# SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2018 Fraunhofer SIT
 # All rights reserved.
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3
+# SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2018 Fraunhofer SIT
 # All rights reserved.
 

--- a/include/tpm2-totp.h
+++ b/include/tpm2-totp.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-3 */
+/* SPDX-License-Identifier: BSD-3-Clause */
 /*******************************************************************************
  * Copyright 2018, Fraunhofer SIT
  * All rights reserved.

--- a/src/libtpm2-totp.c
+++ b/src/libtpm2-totp.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-3 */
+/* SPDX-License-Identifier: BSD-3-Clause */
 /*******************************************************************************
  * Copyright 2018, Fraunhofer SIT
  * All rights reserved.

--- a/src/tpm2-totp-tcti.c
+++ b/src/tpm2-totp-tcti.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-3 */
+/* SPDX-License-Identifier: BSD-3-Clause */
 /*******************************************************************************
  * Copyright 2019, Jonas Witschel
  * All rights reserved.

--- a/src/tpm2-totp-tcti.h
+++ b/src/tpm2-totp-tcti.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-3 */
+/* SPDX-License-Identifier: BSD-3-Clause */
 /*******************************************************************************
  * Copyright 2019, Jonas Witschel
  * All rights reserved.

--- a/src/tpm2-totp.c
+++ b/src/tpm2-totp.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-3 */
+/* SPDX-License-Identifier: BSD-3-Clause */
 /*******************************************************************************
  * Copyright 2018, Fraunhofer SIT
  * Copyright 2018, Jonas Witschel

--- a/test/libtpm2-totp.c
+++ b/test/libtpm2-totp.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: BSD-3 */
+/* SPDX-License-Identifier: BSD-3-Clause */
 /*******************************************************************************
  * Copyright 2018, Fraunhofer SIT
  * All rights reserved.

--- a/test/libtpm2-totp.sh
+++ b/test/libtpm2-totp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-License-Identifier: BSD-3
+# SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2018 Fraunhofer SIT
 # All rights reserved.
 

--- a/test/plymouth-tpm2-totp.sh
+++ b/test/plymouth-tpm2-totp.sh
@@ -1,7 +1,7 @@
+#!/bin/bash
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2019 Jonas Witschel
 # All rights reserved.
-#!/bin/bash
 
 set -eufx
 

--- a/test/sh_log_compiler.sh
+++ b/test/sh_log_compiler.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-License-Identifier: BSD-3
+# SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2019 Jonas Witschel
 # All rights reserved.
 

--- a/test/tpm2-totp.sh
+++ b/test/tpm2-totp.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# SPDX-License-Identifier: BSD-3
+# SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2018 Fraunhofer SIT
 # All rights reserved.
 


### PR DESCRIPTION
The correct short identifier is BSD-3-Clause, see https://spdx.org/licenses/BSD-3-Clause.html and https://github.com/tpm2-software/tpm2-tss/pull/1394.