### PR TITLE
Fix header includes and reduce overlinking

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,9 +6,9 @@
 INCLUDE_DIRS    = -I$(srcdir)/include -I$(srcdir)/src
 ACLOCAL_AMFLAGS = -I m4 --install
 AM_CFLAGS       = $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(TSS2_ESYS_CFLAGS) \
-                  $(QRENCODE_CFLAGS) $(CODE_COVERAGE_CFLAGS)
+                  $(CODE_COVERAGE_CFLAGS)
 AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
-AM_LDADD        = $(TSS2_ESYS_LIBS) $(QRENCODE_LIBS) -ldl
+AM_LDADD        = $(TSS2_ESYS_LIBS)
 
 # Initialize empty variables to be extended throughout
 bin_PROGRAMS =
@@ -48,15 +48,16 @@ DISTCLEANFILES += $(pkgconfig_DATA)
 bin_PROGRAMS += tpm2-totp
 
 tpm2_totp_SOURCES = src/tpm2-totp.c src/tpm2-totp-tcti.c
-tpm2_totp_LDADD = $(AM_LDADD) libtpm2-totp.la
+tpm2_totp_CFLAGS = $(AM_CFLAGS) $(QRENCODE_CFLAGS)
+tpm2_totp_LDADD = $(AM_LDADD) $(QRENCODE_LIBS) -ldl libtpm2-totp.la
 tpm2_totp_LDFLAGS = $(AM_LDFLAGS)
 
 if PLYMOUTH
 libexec_PROGRAMS += plymouth-tpm2-totp
 plymouth_tpm2_totp_SOURCES = src/plymouth-tpm2-totp.c src/tpm2-totp-tcti.c
 plymouth_tpm2_totp_CFLAGS = $(AM_CFLAGS) $(PLY_BOOT_CLIENT_CFLAGS)
-plymouth_tpm2_totp_LDADD = $(AM_LDADD) $(PLY_BOOT_CLIENT_LIBS) libtpm2-totp.la
-plymouth_tpm2_totp_LDFLAGS = $(AM_LDFLAGS) $(PLY_BOOT_CLIENT_LDFLAGS)
+plymouth_tpm2_totp_LDADD = $(AM_LDADD) $(PLY_BOOT_CLIENT_LIBS) -ldl libtpm2-totp.la
+plymouth_tpm2_totp_LDFLAGS = $(AM_LDFLAGS)
 endif # PLYMOUTH
 
 ### Tests ###
@@ -87,7 +88,7 @@ check_PROGRAMS += libtpm2-totp
 
 libtpm2_totp_SOURCES = test/libtpm2-totp.c src/tpm2-totp-tcti.c src/tpm2-totp-tcti.h
 libtpm2_totp_CFLAGS = $(AM_CFLAGS) $(OATH_CFLAGS)
-libtpm2_totp_LDADD = $(AM_LDADD) $(OATH_LIBS) libtpm2-totp.la
+libtpm2_totp_LDADD = $(AM_LDADD) $(OATH_LIBS) -ldl libtpm2-totp.la
 libtpm2_totp_LDFLAGS = $(AM_LDFLAGS) $(OATH_LDFLAGS)
 endif #INTEGRATION
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,13 +47,13 @@ DISTCLEANFILES += $(pkgconfig_DATA)
 ### Executable ###
 bin_PROGRAMS += tpm2-totp
 
-tpm2_totp_SOURCES = src/tpm2-totp.c src/tpm2-totp-tcti.c src/tpm2-totp-tcti.h
+tpm2_totp_SOURCES = src/tpm2-totp.c src/tpm2-totp-tcti.c
 tpm2_totp_LDADD = $(AM_LDADD) libtpm2-totp.la
 tpm2_totp_LDFLAGS = $(AM_LDFLAGS)
 
 if PLYMOUTH
 libexec_PROGRAMS += plymouth-tpm2-totp
-plymouth_tpm2_totp_SOURCES = src/plymouth-tpm2-totp.c src/tpm2-totp-tcti.c src/tpm2-totp-tcti.h
+plymouth_tpm2_totp_SOURCES = src/plymouth-tpm2-totp.c src/tpm2-totp-tcti.c
 plymouth_tpm2_totp_CFLAGS = $(AM_CFLAGS) $(PLY_BOOT_CLIENT_CFLAGS)
 plymouth_tpm2_totp_LDADD = $(AM_LDADD) $(PLY_BOOT_CLIENT_LIBS) libtpm2-totp.la
 plymouth_tpm2_totp_LDFLAGS = $(AM_LDFLAGS) $(PLY_BOOT_CLIENT_LDFLAGS)

--- a/include/tpm2-totp.h
+++ b/include/tpm2-totp.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 #include <time.h>
-#include <tss2/tss2_esys.h>
+#include <tss2/tss2_tcti.h>
 
 #define TPM2TOTP_BANK_SHA1 (1 << 0)
 #define TPM2TOTP_BANK_SHA256 (1 << 1)

--- a/src/libtpm2-totp.c
+++ b/src/libtpm2-totp.c
@@ -8,7 +8,6 @@
 
 #include <tpm2-totp.h>
 
-#include <endian.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/plymouth-tpm2-totp.c
+++ b/src/plymouth-tpm2-totp.c
@@ -8,7 +8,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 #include <inttypes.h>
 #include <getopt.h>
 #include <ply-boot-client.h>

--- a/src/tpm2-totp-tcti.c
+++ b/src/tpm2-totp-tcti.c
@@ -10,7 +10,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <dlfcn.h>
-#include <tss2/tss2_tcti.h>
 
 #define ERR(...) fprintf(stderr, __VA_ARGS__)
 

--- a/test/libtpm2-totp.c
+++ b/test/libtpm2-totp.c
@@ -7,7 +7,7 @@
 #include <tpm2-totp.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
+#include <string.h>
 #include <liboath/oath.h>
 
 #include "tpm2-totp-tcti.h"


### PR DESCRIPTION
- `tpm2-totp.h` doesn't need to include the full [`tss2/tss2_esys.h`](https://github.com/tpm2-software/tpm2-tss/blob/master/include/tss2/tss2_esys.h) because it doesn't any of these functions or types, it only needs [`tss2/tss2_tcti.h`](https://github.com/tpm2-software/tpm2-tss/blob/master/include/tss2/tss2_tcti.h) for the `TSS2_TCTI_CONTEXT` type. Also remove some unnecessary or duplicate headers with the help of [deheader](http://www.catb.org/~esr/deheader/).
- Don't add libqrencode and libdl to every binary and library, but only to the ones that actually use them. This reduces [overlinking](http://wiki.rosalab.ru/ru/index.php/Overlinking), which can be detected using `ldd -u -r`. It doesn't fix all problems though:
    - `libtpm2-totp.so` includes an unnecessary reference to `libtss2-sys.so`. This is an upstream problem with the tpm2-tss pkg-config files, see https://github.com/tpm2-software/tpm2-tss/pull/1417 for a potential solution.
    - tss2-esys is [unnecessarily linked into all binaries](https://github.com/tpm2-software/tpm2-totp/blob/1a90bdc499d641d577c7bdcaaa77ff72bf7c0389/Makefile.am#L8) while it would be enough for them to depend on `libtpm2-totp.so`. Similar to the changes to libqrencode and libdl, we can remove it from `AM_CFLAGS`/`AM_LDADD`, but this doesn't help since we use libtool which [automatically links all library dependencies into any binary using the library](http://wiki.rosalab.ru/ru/index.php/Overlinking#libtool_issues). Changing this behaviour requires a patched version of libtool as provided e.g. by Debian.