### PR TITLE
build: link against tss2-mu

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,9 +6,9 @@
 INCLUDE_DIRS    = -I$(srcdir)/include -I$(srcdir)/src
 ACLOCAL_AMFLAGS = -I m4 --install
 AM_CFLAGS       = $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(TSS2_ESYS_CFLAGS) \
-                  $(CODE_COVERAGE_CFLAGS)
+                  $(TSS2_MU_CFLAGS) $(CODE_COVERAGE_CFLAGS)
 AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
-AM_LDADD        = $(TSS2_ESYS_LIBS)
+AM_LDADD        = $(TSS2_ESYS_LIBS) $(TSS2_MU_LIBS)
 
 # Initialize empty variables to be extended throughout
 bin_PROGRAMS =

--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,7 @@ AS_IF([test "x$enable_debug" != "xno"],
 
 PKG_PROG_PKG_CONFIG([0.25])
 PKG_CHECK_MODULES([TSS2_ESYS],[tss2-esys])
+PKG_CHECK_MODULES([TSS2_MU],[tss2-mu])
 PKG_CHECK_MODULES([QRENCODE],[libqrencode])
 
 AC_PATH_PROG([PANDOC], [pandoc])


### PR DESCRIPTION
Currently the linking of `libtpm2-totp` relies on the fact that the upstream tpm2-tss pkg-config file explicitly requires tss2-mu. Since this is wrong and will be changed upstream, but we need access to the marshalling functions, explicitly link against tss2-mu. See https://github.com/tpm2-software/tpm2-tss/pull/1417 for a more detailed discussion.