### PR TITLE
src: fix compilation failure due to "variable may be used uninitialized"

### DIFF
--- a/src/tpm2-totp.c
+++ b/src/tpm2-totp.c
@@ -93,7 +93,7 @@ int
 parse_pcrs(char *str, int *pcrs)
 {
     char *token;
-    char *saveptr;
+    char *saveptr = NULL;
     char *endptr;
     long pcr;
 


### PR DESCRIPTION
Apply the patch provided by @casantos to fix #32.