### PR TITLE
ci: use tpm2-tss master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,9 +63,9 @@ install:
   - tar xJf autoconf-archive-2017.09.28.tar.xz
   - cp autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
 # TPM2-TSS
-  - git clone --depth=1 -b 2.1.0 https://github.com/tpm2-software/tpm2-tss.git
+  - git clone --depth=1 https://github.com/tpm2-software/tpm2-tss.git
   - pushd tpm2-tss
-  - cp ../autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
+  - cp ../autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 ../autoconf-archive-2017.09.28/m4/ax_is_release.m4 m4/
   - ./bootstrap
   - ./configure --with-crypto=ossl CFLAGS=-I${PWD}/../installdir/usr/local/include LDFLAGS=-L${PWD}/../installdir/usr/local/lib
   - make -j$(nproc)


### PR DESCRIPTION
Since https://github.com/tpm2-software/tpm2-tools/commit/893e43271024e9c2d942c8dc9ba1657a667bb0e2 tpm2-tools explicitly requires tpm2-tss >=2.3.0, so we need to use the development instead of the stable version in Travis CI.