### PR TITLE
ci: use tpm2-tools 3.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,10 +73,10 @@ install:
   - rm ${PWD}/../installdir/usr/local/lib/*.la
   - popd
 # tpm2-tools
-  - git clone --depth=1 https://github.com/tpm2-software/tpm2-tools.git
+  - git clone --depth=1 -b 3.X https://github.com/tpm2-software/tpm2-tools.git
   - pushd tpm2-tools
   - mkdir m4 || true
-  - cp ../autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 ../autoconf-archive-2017.09.28/m4/ax_is_release.m4 m4/
+  - cp ../autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
   - ./bootstrap
   # Some workarounds for tpm2-tools with -Wno-XXX
   - ./configure --disable-hardening CFLAGS="-I${PWD}/../installdir/usr/local/include -Wno-unused-value -Wno-missing-field-initializer" LDFLAGS=-L${PWD}/../installdir/usr/local/lib


### PR DESCRIPTION
Since https://github.com/tpm2-software/tpm2-tools/commit/893e43271024e9c2d942c8dc9ba1657a667bb0e2 tpm2-tools explicitly requires tpm2-tss >=2.3.0, so we switch to the stable version of tpm2-tools instead. We only need `tpm2_pcrextend` anyway, which didn't have any API-breaking changes.