### PR TITLE
pkg-config: add dependency on tss2-mu

### DIFF
--- a/dist/tpm2-totp.pc.in
+++ b/dist/tpm2-totp.pc.in
@@ -7,6 +7,6 @@ Name: tpm2-totp
 Description: Attest the trustworthiness of a device against a human using time-based one-time passwords
 URL: https://github.com/tpm2-software/tpm2-totp
 Version: @VERSION@
-Requires.private: tss2-esys
+Requires.private: tss2-esys tss2-mu
 Cflags: -I${includedir}
 Libs: -L${libdir} -ltpm2-totp


### PR DESCRIPTION
In #31 I added tss2-mu as a dependency in preparation for https://github.com/tpm2-software/tpm2-tss/pull/1417, so it should be a private dependency (for static linking) in the pkg-config file as well.