### PR TITLE
 dist: add dracut module for plymouth-tpm2-totp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ config.sub
 configure
 depcomp
 dist/*.pc
+dist/dracut/module-setup.sh
 dist/initcpio/install/plymouth-tpm2-totp
 install-sh
 libtool

--- a/Makefile.am
+++ b/Makefile.am
@@ -137,6 +137,15 @@ EXTRA_DIST += \
 CLEANFILES += \
     $(man1_MANS)
 
+### initramfs hooks ###
+
+if HAVE_DRACUT
+if PLYMOUTH
+dracut_DATA = dist/dracut/module-setup.sh dist/dracut/tpm2-totp.sh
+endif # PLYMOUTH
+endif # HAVE_DRACUT
+EXTRA_DIST += dist/dracut/tpm2-totp.sh
+
 if HAVE_MKINITCPIO
 initcpio_install_DATA = dist/initcpio/install/tpm2-totp
 initcpio_hooks_DATA = dist/initcpio/hooks/tpm2-totp

--- a/Makefile.am
+++ b/Makefile.am
@@ -52,13 +52,13 @@ tpm2_totp_CFLAGS = $(AM_CFLAGS) $(QRENCODE_CFLAGS)
 tpm2_totp_LDADD = $(AM_LDADD) $(QRENCODE_LIBS) -ldl libtpm2-totp.la
 tpm2_totp_LDFLAGS = $(AM_LDFLAGS)
 
-if PLYMOUTH
+if HAVE_PLYMOUTH
 libexec_PROGRAMS += plymouth-tpm2-totp
 plymouth_tpm2_totp_SOURCES = src/plymouth-tpm2-totp.c src/tpm2-totp-tcti.c
 plymouth_tpm2_totp_CFLAGS = $(AM_CFLAGS) $(PLY_BOOT_CLIENT_CFLAGS)
 plymouth_tpm2_totp_LDADD = $(AM_LDADD) $(PLY_BOOT_CLIENT_LIBS) -ldl libtpm2-totp.la
 plymouth_tpm2_totp_LDFLAGS = $(AM_LDFLAGS)
-endif # PLYMOUTH
+endif # HAVE_PLYMOUTH
 
 ### Tests ###
 TESTS =
@@ -70,9 +70,9 @@ if HAVE_MKINITCPIO
 TESTS += $(TESTS_MKINITCPIO)
 endif # HAVE_MKINITCPIO
 
-if PLYMOUTH
+if HAVE_PLYMOUTH
 TESTS += $(TESTS_PLYMOUTH)
-endif # PLYMOUTH
+endif # HAVE_PLYMOUTH
 endif #INTEGRATION
 TESTS_SHELL = test/libtpm2-totp.sh \
               test/tpm2-totp.sh
@@ -140,19 +140,19 @@ CLEANFILES += \
 ### initramfs hooks ###
 
 if HAVE_DRACUT
-if PLYMOUTH
+if HAVE_PLYMOUTH
 dracut_DATA = dist/dracut/module-setup.sh dist/dracut/tpm2-totp.sh
-endif # PLYMOUTH
+endif # HAVE_PLYMOUTH
 endif # HAVE_DRACUT
 EXTRA_DIST += dist/dracut/tpm2-totp.sh
 
 if HAVE_MKINITCPIO
 initcpio_install_DATA = dist/initcpio/install/tpm2-totp
 initcpio_hooks_DATA = dist/initcpio/hooks/tpm2-totp
-if PLYMOUTH
+if HAVE_PLYMOUTH
 initcpio_install_DATA += dist/initcpio/install/plymouth-tpm2-totp
 initcpio_hooks_DATA += dist/initcpio/hooks/plymouth-tpm2-totp
-endif # PLYMOUTH
+endif # HAVE_PLYMOUTH
 endif # HAVE_MKINITCPIO
 EXTRA_DIST += \
 	dist/initcpio/install/tpm2-totp \

--- a/configure.ac
+++ b/configure.ac
@@ -111,15 +111,14 @@ AS_IF([test "x$enable_plymouth" != "xno"],
       [PKG_CHECK_MODULES([PLY_BOOT_CLIENT], [ply-boot-client],
                          [have_plymouth=yes], [have_plymouth=no])],
       [have_plymouth=no])
-AM_CONDITIONAL([PLYMOUTH], [test "x$have_plymouth" = "xyes"])
-AS_IF([test "x$have_plymouth" = "xyes"],
-      [PKG_CHECK_VAR([PLYMOUTHPLUGINSDIR], [ply-splash-core], [pluginsdir])
-       AC_SUBST([PLYMOUTHPLUGINSDIR])
-      ],
-      [AS_IF([test "x$enable_plymouth" = "xyes"],
-             [AC_MSG_ERROR([plymouth requested but not found])
-      ])
-])
+AM_CONDITIONAL([HAVE_PLYMOUTH], [test "x$have_plymouth" = "xyes"])
+AM_COND_IF([HAVE_PLYMOUTH],
+           [PKG_CHECK_VAR([PLYMOUTHPLUGINSDIR], [ply-splash-core], [pluginsdir])
+            AC_SUBST([PLYMOUTHPLUGINSDIR])
+           ],
+           [AS_IF([test "x$enable_plymouth" = "xyes"],
+                  [AC_MSG_ERROR([plymouth requested but not found])])
+           ])
 
 AC_ARG_ENABLE([integration],
             [AS_HELP_STRING([--enable-integration],
@@ -138,7 +137,7 @@ AS_IF([test "x$enable_integration" != xno],
        AS_IF([test "x$ss" != xyes],
              [AC_MSG_ERROR([Integration tests require the ss executable])])
 
-       AS_IF([test "x$have_plymouth" = "xyes"],
+       AM_COND_IF([HAVE_PLYMOUTH],
              [AC_CHECK_PROG([plymouthd], [plymouthd], [yes])
               AS_IF([test "x$plymouthd" != xyes],
                     [AC_MSG_ERROR([Integration tests require the plymouthd executable])])

--- a/configure.ac
+++ b/configure.ac
@@ -95,16 +95,15 @@ AC_ARG_WITH([dracutmodulesdir],
 AM_CONDITIONAL(HAVE_DRACUT, [test -n "$with_dracutmodulesdir" -a "x$with_dracutmodulesdir" != xno])
 AM_COND_IF([HAVE_DRACUT], [AC_SUBST([dracutdir], [$with_dracutmodulesdir/70tpm2-totp])])
 
-AC_ARG_WITH([mkinitcpiodir],
-            AS_HELP_STRING([--with-mkinitcpiodir=DIR], [directory for mkinitcpio hooks]))
 AC_CHECK_PROG([mkinitcpio], [mkinitcpio], [yes])
-AS_IF([test "x$mkinitcpio" = xyes -a -z "$with_mkinitcpiodir"],
-      [with_mkinitcpiodir=$sysconfdir/initcpio])
-AS_IF([test "x$with_mkinitcpiodir" != xno],
-      [AC_SUBST([initcpio_installdir], [$with_mkinitcpiodir/install])
-       AC_SUBST([initcpio_hooksdir], [$with_mkinitcpiodir/hooks])
-      ])
+AC_ARG_WITH([mkinitcpiodir],
+            AS_HELP_STRING([--with-mkinitcpiodir=DIR], [directory for mkinitcpio hooks]),,
+            [AS_IF([test "x$mkinitcpio" = xyes], [with_mkinitcpiodir=$sysconfdir/initcpio])])
 AM_CONDITIONAL(HAVE_MKINITCPIO, [test -n "$with_mkinitcpiodir" -a "x$with_mkinitcpiodir" != xno])
+AM_COND_IF([HAVE_MKINITCPIO],
+           [AC_SUBST([initcpio_installdir], [$with_mkinitcpiodir/install])
+            AC_SUBST([initcpio_hooksdir], [$with_mkinitcpiodir/hooks])
+           ])
 
 AC_ARG_ENABLE([plymouth],
               AS_HELP_STRING([--disable-plymouth], [Disable plymouth support]))

--- a/configure.ac
+++ b/configure.ac
@@ -45,7 +45,7 @@ PKG_INSTALLDIR()
 AX_RECURSIVE_EVAL([$libexecdir], [LIBEXECDIR])
 AC_SUBST([LIBEXECDIR])
 
-AC_CONFIG_FILES([Makefile dist/tpm2-totp.pc dist/initcpio/install/plymouth-tpm2-totp])
+AC_CONFIG_FILES([Makefile dist/tpm2-totp.pc dist/dracut/module-setup.sh dist/initcpio/install/plymouth-tpm2-totp])
 
 AX_ADD_COMPILER_FLAG([-std=c99])
 AX_ADD_COMPILER_FLAG([-Wall])
@@ -89,6 +89,12 @@ AS_IF([test -z "$PANDOC"],
 AM_CONDITIONAL([HAVE_PANDOC],[test -n "$PANDOC"])
 AM_CONDITIONAL([HAVE_MAN_PAGES],[test -d "${srcdir}/man/man1" -o -n "$PANDOC"])
 
+AC_ARG_WITH([dracutmodulesdir],
+            AS_HELP_STRING([--with-dracutmodulesdir=DIR], [directory for dracut hooks]),,
+            [PKG_CHECK_VAR([with_dracutmodulesdir], [dracut], [dracutmodulesdir])])
+AM_CONDITIONAL(HAVE_DRACUT, [test -n "$with_dracutmodulesdir" -a "x$with_dracutmodulesdir" != xno])
+AM_COND_IF([HAVE_DRACUT], [AC_SUBST([dracutdir], [$with_dracutmodulesdir/70tpm2-totp])])
+
 AC_ARG_WITH([mkinitcpiodir],
             AS_HELP_STRING([--with-mkinitcpiodir=DIR], [directory for mkinitcpio hooks]))
 AC_CHECK_PROG([mkinitcpio], [mkinitcpio], [yes])
@@ -107,7 +113,10 @@ AS_IF([test "x$enable_plymouth" != "xno"],
                          [have_plymouth=yes], [have_plymouth=no])],
       [have_plymouth=no])
 AM_CONDITIONAL([PLYMOUTH], [test "x$have_plymouth" = "xyes"])
-AS_IF([test "x$have_plymouth" = "xyes"],,
+AS_IF([test "x$have_plymouth" = "xyes"],
+      [PKG_CHECK_VAR([PLYMOUTHPLUGINSDIR], [ply-splash-core], [pluginsdir])
+       AC_SUBST([PLYMOUTHPLUGINSDIR])
+      ],
       [AS_IF([test "x$enable_plymouth" = "xyes"],
              [AC_MSG_ERROR([plymouth requested but not found])
       ])
@@ -156,6 +165,7 @@ AC_OUTPUT
 AC_MSG_RESULT([
 $PACKAGE_NAME $VERSION
     man-pages:  $PANDOC
+    dracut:     $with_dracutmodulesdir
     mkinitcpio: $with_mkinitcpiodir
     plymouth:   $have_plymouth
 ])

--- a/dist/dracut/module-setup.sh.in
+++ b/dist/dracut/module-setup.sh.in
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+check() {
+    if [ -n "$hostonly" ]; then
+        if tpm2-totp calculate >/dev/null 2>&1; then
+            return 0
+        else
+            dinfo "dracut module 'tpm2-totp' will not be installed because no TOTP is configured; run 'tpm2-totp generate'!"
+        fi
+    fi
+    return 255
+}
+
+depends() {
+    echo plymouth
+}
+
+install() {
+    inst @LIBEXECDIR@/plymouth-tpm2-totp /bin/plymouth-tpm2-totp
+    inst_library @PLYMOUTHPLUGINSDIR@/label.so
+    inst_simple /usr/share/fonts/TTF/DejaVuSans.ttf
+    inst_hook pre-udev 70 "$moddir/tpm2-totp.sh"
+    dracut_need_initqueue
+}
+
+installkernel() {
+    instmods =drivers/char/tpm
+}

--- a/dist/dracut/tpm2-totp.sh
+++ b/dist/dracut/tpm2-totp.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+. /lib/dracut-lib.sh
+nvindex="$(getarg rd.tpm2-totp.nvindex)"
+export TSS2_LOG
+printf 'KERNEL=="tpm0", RUN+="/sbin/initqueue --settled --onetime --env TSS2_LOG=esys+error /bin/plymouth-tpm2-totp %s &"\n' "${nvindex:+--nvindex "$nvindex"}" > /etc/udev/rules.d/80-tpm2-totp.rules
+unset nvindex

--- a/dist/initcpio/install/plymouth-tpm2-totp.in
+++ b/dist/initcpio/install/plymouth-tpm2-totp.in
@@ -11,7 +11,7 @@ build() {
         add_all_modules /tpm/
     fi
 
-    add_binary /usr/lib/plymouth/label.so
+    add_binary @PLYMOUTHPLUGINSDIR@/label.so
     add_file /usr/share/fonts/TTF/DejaVuSans.ttf
 
     add_binary @LIBEXECDIR@/plymouth-tpm2-totp /usr/bin/plymouth-tpm2-totp


### PR DESCRIPTION
Add a [dracut](https://dracut.wiki.kernel.org/index.php/Main_Page) module to display the TOTP during boot. Since most distributions using dracut will have plymouth as well, use [plymouth-tpm2-totp](https://github.com/tpm2-software/tpm2-totp/blob/master/src/plymouth-tpm2-totp.c) for this purpose.

The module is comparable to the already existing [mkinitcpio hooks](https://github.com/tpm2-software/tpm2-totp/tree/master/dist/initcpio), but with dracut we can use udev in order to wait for the TPM to be detected by the kernel, which might help avoiding some race conditions.

Since we now detect the plymouth installation location using pkg-config, we can use this for the mkinitcpio hooks as well, making them more robust against custom installation locations. Also simplify the mkinitcpio hooks directory detection a bit to look similar to the new dracut code and rename `PLYMOUTH` to `HAVE_PLYMOUTH` for consistency.