### PR TITLE
dist: let fontconfig choose an appropriate font

### DIFF
--- a/dist/dracut/module-setup.sh.in
+++ b/dist/dracut/module-setup.sh.in
@@ -18,7 +18,7 @@ depends() {
 install() {
     inst @LIBEXECDIR@/plymouth-tpm2-totp /bin/plymouth-tpm2-totp
     inst_library @PLYMOUTHPLUGINSDIR@/label.so
-    inst_simple /usr/share/fonts/TTF/DejaVuSans.ttf
+    inst_simple "$(fc-match --format '%{file}')"
     inst_hook pre-udev 70 "$moddir/tpm2-totp.sh"
     dracut_need_initqueue
 }

--- a/dist/initcpio/install/plymouth-tpm2-totp.in
+++ b/dist/initcpio/install/plymouth-tpm2-totp.in
@@ -12,7 +12,7 @@ build() {
     fi
 
     add_binary @PLYMOUTHPLUGINSDIR@/label.so
-    add_file /usr/share/fonts/TTF/DejaVuSans.ttf
+    add_file "$(fc-match --format '%{file}')"
 
     add_binary @LIBEXECDIR@/plymouth-tpm2-totp /usr/bin/plymouth-tpm2-totp
 


### PR DESCRIPTION
Instead of hardcoding a path for DejaVu Sans which might not be available or in a different location, use `fc-match` to use ["the normal fontconfig matching rules to find the best font available"](https://linux.die.net/man/1/fc-match).

I am not entirely happy that we have to add `label.so` and a font manually in our hooks, this is something that either upstream plymouth or the individual distributions should do depending on the selected plymouth theme. Debian and openSUSE seem to do that, Arch and Fedora (probably, not completely sure about that) don't. Therefore we do it in our own hooks as portable as possible since possibly doing it twice won't lead to conflicts.