### PR TITLE
doc: remove SHA-384 from the default banks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ build options are available in the [INSTALL](INSTALL.md) file.
 ## Setup
 The TOTP secret can be generated with and without password. It is recommended to
 set a password `-P`in order to enable recovery options. Also the PCRs and PCR
-banks can be selected `-p` and `-b`. Default values are PCRs `0,2,4` and all
-available banks from the list `SHA1, SHA256, SHA384`.
+banks can be selected `-p` and `-b`. Default values are PCRs `0,2,4` and
+banks `SHA1, SHA256`.
 ```
 tpm2-totp generate
 tpm2-totp -P verysecret generate

--- a/man/tpm2-totp.1.md
+++ b/man/tpm2-totp.1.md
@@ -45,7 +45,7 @@ options.
 ## OPTIONS
 
   * `-b <bank>[,<bank>[,...]]`, `--banks <bank>[,<bank>[,...]]`:
-    Selected PCR banks (default: SHA1,SHA256,SHA384)
+    Selected PCR banks (default: SHA1,SHA256)
 
   * `-h`, `--help`:
     Print help
@@ -81,8 +81,8 @@ options.
 ## Setup
 The TOTP secret can be generated with and without password. It is recommended to
 set a password `-P`in order to enable recovery options. Also the PCRs and PCR
-banks can be selected `-p` and `-b`. Default values are PCRs `0,2,4` and all
-available banks from the list `SHA1, SHA256, SHA384`.
+banks can be selected `-p` and `-b`. Default values are PCRs `0,2,4` and
+banks `SHA1, SHA256`.
 ```
 tpm2-totp generate
 tpm2-totp -P verysecret generate


### PR DESCRIPTION
#11 removed SHA-384 from the default banks, so update the documentation to reflect that.