### PR TITLE
build: fix make distcheck without sudo

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,6 +10,8 @@ AM_CFLAGS       = $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(TSS2_ESYS_CFLAGS) \
 AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
 AM_LDADD        = $(TSS2_ESYS_LIBS) $(TSS2_MU_LIBS)
 
+AM_DISTCHECK_CONFIGURE_FLAGS = --with-dracutmodulesdir='$$(libdir)/dracut/modules.d'
+
 # Initialize empty variables to be extended throughout
 bin_PROGRAMS =
 libexec_PROGRAMS =


### PR DESCRIPTION
[`dracutdir`](https://github.com/tpm2-software/tpm2-totp/blob/9e68586fd4f93d9cf27d3c1bff333e3bf5e563ec/configure.ac#L103) is derived [using pkg-config](https://github.com/tpm2-software/tpm2-totp/blob/9e68586fd4f93d9cf27d3c1bff333e3bf5e563ec/configure.ac#L101), therefore it doesn't respect `${prefix}`. Hence `make distcheck` will try to install to an absolute path instead of the temporary installation directory, which usually fails without root privileges (and is not desired anyway). Fix this by providing distcheck with the default `dracutmodulesdir` path derived from `${prefix}`.