### PR TITLE
dist: install tss2-tcti-device to initramfs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,9 +56,9 @@ install:
   - pushd tpm2-tss
   - cp ../autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
   - ./bootstrap
-  - ./configure
+  - ./configure --prefix=${PWD}/../installdir/usr/local
   - make -j$(nproc)
-  - make install DESTDIR=${PWD}/../installdir
+  - make install
   - rm ${PWD}/../installdir/usr/local/lib/*.la
   - popd
 # tpm2-tools
@@ -68,9 +68,9 @@ install:
   - cp ../autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
   - ./bootstrap
   # Some workarounds for tpm2-tools with -Wno-XXX
-  - ./configure --disable-hardening CFLAGS="-I${PWD}/../installdir/usr/local/include -Wno-unused-value -Wno-missing-field-initializer" LDFLAGS=-L${PWD}/../installdir/usr/local/lib
+  - ./configure --disable-hardening CFLAGS="-I${PWD}/../installdir/usr/local/include -Wno-unused-value -Wno-missing-field-initializer" LDFLAGS=-L${PWD}/../installdir/usr/local/lib --prefix=${PWD}/../installdir/usr/local
   - make -j$(nproc)
-  - make install DESTDIR=${PWD}/../installdir
+  - make install
   - popd
 
 before_script:

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ PKG_INSTALLDIR()
 AX_RECURSIVE_EVAL([$libexecdir], [LIBEXECDIR])
 AC_SUBST([LIBEXECDIR])
 
-AC_CONFIG_FILES([Makefile Doxyfile dist/tpm2-totp.pc dist/dracut/module-setup.sh dist/initcpio/install/plymouth-tpm2-totp])
+AC_CONFIG_FILES([Makefile Doxyfile dist/tpm2-totp.pc dist/dracut/module-setup.sh dist/initcpio/install/tpm2-totp dist/initcpio/install/plymouth-tpm2-totp])
 
 AC_ARG_ENABLE([defaultflags],
               [AS_HELP_STRING([--disable-defaultflags],
@@ -85,6 +85,8 @@ AX_ADD_AM_MACRO_STATIC([])
 PKG_PROG_PKG_CONFIG([0.25])
 PKG_CHECK_MODULES([TSS2_ESYS],[tss2-esys])
 PKG_CHECK_MODULES([TSS2_MU],[tss2-mu])
+PKG_CHECK_VAR([TSS2_TCTI_DEVICE_LIBDIR], [tss2-tcti-device], [libdir])
+AC_SUBST([TSS2_TCTI_DEVICE_LIBDIR])
 PKG_CHECK_MODULES([QRENCODE],[libqrencode])
 
 DX_DOXYGEN_FEATURE(ON)

--- a/configure.ac
+++ b/configure.ac
@@ -86,6 +86,14 @@ PKG_PROG_PKG_CONFIG([0.25])
 PKG_CHECK_MODULES([TSS2_ESYS],[tss2-esys])
 PKG_CHECK_MODULES([TSS2_MU],[tss2-mu])
 PKG_CHECK_VAR([TSS2_TCTI_DEVICE_LIBDIR], [tss2-tcti-device], [libdir])
+# Fallback for old versions of tpm2-tss without the libdir pkg-config variable
+AS_IF([test "x$TSS2_TCTI_DEVICE_LIBDIR" = "x"],
+      [TSS2_TCTI_DEVICE_LIBDIR=`PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 $PKG_CONFIG --libs-only-L tss2-tcti-device`
+       TSS2_TCTI_DEVICE_LIBDIR=${TSS2_TCTI_DEVICE_LIBDIR#-L}
+       TSS2_TCTI_DEVICE_LIBDIR=${TSS2_TCTI_DEVICE_LIBDIR% }
+      ])
+AC_CHECK_FILE([$TSS2_TCTI_DEVICE_LIBDIR/libtss2-tcti-device.so], ,
+              [AC_MSG_ERROR([Required file libtss2-tcti-device.so not found])])
 AC_SUBST([TSS2_TCTI_DEVICE_LIBDIR])
 PKG_CHECK_MODULES([QRENCODE],[libqrencode])
 

--- a/dist/dracut/module-setup.sh.in
+++ b/dist/dracut/module-setup.sh.in
@@ -17,6 +17,7 @@ depends() {
 
 install() {
     inst @LIBEXECDIR@/plymouth-tpm2-totp /bin/plymouth-tpm2-totp
+    inst_libdir_file 'libtss2-tcti-device.so*'
     inst_library @PLYMOUTHPLUGINSDIR@/label.so
     inst_simple "$(fc-match --format '%{file}')"
     inst_hook pre-udev 70 "$moddir/tpm2-totp.sh"

--- a/dist/dracut/tpm2-totp.sh
+++ b/dist/dracut/tpm2-totp.sh
@@ -2,5 +2,5 @@
 . /lib/dracut-lib.sh
 nvindex="$(getarg rd.tpm2-totp.nvindex)"
 export TSS2_LOG
-printf 'KERNEL=="tpm0", RUN+="/sbin/initqueue --settled --onetime --env TSS2_LOG=esys+error /bin/plymouth-tpm2-totp %s &"\n' "${nvindex:+--nvindex "$nvindex"}" > /etc/udev/rules.d/80-tpm2-totp.rules
+printf 'KERNEL=="tpm0", RUN+="/sbin/initqueue --settled --onetime --env TSS2_LOG=tcti+error /bin/plymouth-tpm2-totp %s &"\n' "${nvindex:+--nvindex "$nvindex"}" > /etc/udev/rules.d/80-tpm2-totp.rules
 unset nvindex

--- a/dist/initcpio/hooks/plymouth-tpm2-totp
+++ b/dist/initcpio/hooks/plymouth-tpm2-totp
@@ -1,7 +1,7 @@
 #!/usr/bin/ash
 
 run_hook() {
-    TSS2_LOG=esys+error plymouth-tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} &
+    TSS2_LOG=tcti+error plymouth-tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} &
 }
 
 # vim: set ft=sh ts=4 sw=4 et:

--- a/dist/initcpio/hooks/tpm2-totp
+++ b/dist/initcpio/hooks/tpm2-totp
@@ -2,10 +2,10 @@
 
 run_hook() {
     echo 'Verify the TOTP (press any key to continue):'
-    TSS2_LOG=esys+error tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} --time calculate
+    TSS2_LOG=tcti+error tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} --time calculate
     echo
     while ! read -n 1 -r -s -t 10; do
-        TSS2_LOG=esys+error tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} --time calculate
+        TSS2_LOG=tcti+error tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} --time calculate
         echo
     done
 }

--- a/dist/initcpio/install/plymouth-tpm2-totp.in
+++ b/dist/initcpio/install/plymouth-tpm2-totp.in
@@ -15,6 +15,7 @@ build() {
     add_file "$(fc-match --format '%{file}')"
 
     add_binary @LIBEXECDIR@/plymouth-tpm2-totp /usr/bin/plymouth-tpm2-totp
+    add_binary @TSS2_TCTI_DEVICE_LIBDIR@/libtss2-tcti-device.so
 
     add_runscript
 }

--- a/dist/initcpio/install/tpm2-totp.in
+++ b/dist/initcpio/install/tpm2-totp.in
@@ -12,6 +12,7 @@ build() {
     fi
 
     add_binary tpm2-totp
+    add_binary @TSS2_TCTI_DEVICE_LIBDIR@/libtss2-tcti-device.so
 
     add_runscript
 }


### PR DESCRIPTION
Since https://github.com/tpm2-software/tpm2-tss/commit/b258ab9618ded645777917a742b917a3ba72f107 `libtss2-esys.so` does not directly depend on `libtss2-tcti-device.so` any more, so we need to install the TCTI library manually to the initramfs.

The same commit moves the warning about missing TCTI libraries from the `esys` to the `tcti` module, so the `TSS2_LOG` environment variable needs to be updated as well.