### PR TITLE
build: cleanup DISTCLEANFILES and add -O2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,7 @@ install:
   - cp autoconf-archive-2017.09.28/m4/ax_code_coverage.m4 m4/
   - cp autoconf-archive-2017.09.28/m4/ax_prog_doxygen.m4 m4/
   - cp autoconf-archive-2017.09.28/m4/ax_is_release.m4 m4/
+  - cp autoconf-archive-2017.09.28/m4/ax_add_fortify_source.m4 m4/
 # TPM2-TSS
   - git clone --depth=1 -b 2.1.0 https://github.com/tpm2-software/tpm2-tss.git
   - pushd tpm2-tss

--- a/Makefile.am
+++ b/Makefile.am
@@ -73,7 +73,6 @@ libtpm2_totp_la_LIBADD = $(AM_LDADD)
 libtpm2_totp_la_LDFLAGS = $(AM_LDFLAGS) '(tpm2_totp)'
 
 pkgconfig_DATA = dist/tpm2-totp.pc
-DISTCLEANFILES += $(pkgconfig_DATA)
 
 ### Executable ###
 bin_PROGRAMS += tpm2-totp

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,7 @@ AS_IF([test "x$enable_defaultflags" = "xyes"],
       AX_ADD_COMPILER_FLAG([-fstack-protector-all])
       AX_ADD_COMPILER_FLAG([-fpic])
       AX_ADD_COMPILER_FLAG([-fPIC])
+      AX_ADD_COMPILER_FLAG([-O2])
       AX_ADD_FORTIFY_SOURCE
 
       # work around GCC bug #53119

--- a/src/tpm2-totp.c
+++ b/src/tpm2-totp.c
@@ -93,12 +93,15 @@ int
 parse_pcrs(char *str, int *pcrs)
 {
     char *token;
-    char *saveptr = NULL;
+    char *saveptr;
     char *endptr;
     long pcr;
 
     *pcrs = 0;
 
+    if (!str) {
+        return -1;
+    }
     token = strtok_r(str, ",", &saveptr);
     if (!token) {
         return -1;


### PR DESCRIPTION
- `dist/tpm2-totp.pc` is generated by `AC_CONFIG_FILES` and therefore cleaned up automatically by Autoconf.
- As in https://github.com/tpm2-software/tpm2-tools/pull/1590, `-O2` needs to be added to the compiler flags to avoid a compilation warning/error due to fortification.
- The Autoconf Archive version in Travis CI [doesn't support `AX_ADD_FORTIFY_SOURCE`](https://travis-ci.org/tpm2-software/tpm2-totp/jobs/541382168#L1496), `ax_add_fortify_source.m4` from a newer version needs to be installed.