### PR TITLE
 dist: add initramfs-tools scripts for plymouth-tpm2-totp

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -186,6 +186,14 @@ endif # HAVE_PLYMOUTH
 endif # HAVE_DRACUT
 EXTRA_DIST += dist/dracut/tpm2-totp.sh
 
+if HAVE_INITRAMFSTOOLS
+if HAVE_PLYMOUTH
+initramfstools_hooks_SCRIPTS = dist/initramfs-tools/hooks/tpm2-totp
+initramfstools_scripts_SCRIPTS = dist/initramfs-tools/scripts/init-premount/tpm2-totp
+endif # HAVE_PLYMOUTH
+endif # HAVE_INITRAMFSTOOLS
+EXTRA_DIST += dist/initramfs-tools/scripts/init-premount/tpm2-totp
+
 if HAVE_MKINITCPIO
 initcpio_install_DATA = dist/initcpio/install/tpm2-totp
 initcpio_hooks_DATA = dist/initcpio/hooks/tpm2-totp

--- a/Makefile.am
+++ b/Makefile.am
@@ -181,7 +181,7 @@ endif # HAVE_DOXYGEN
 
 if HAVE_DRACUT
 if HAVE_PLYMOUTH
-dracut_DATA = dist/dracut/module-setup.sh dist/dracut/tpm2-totp.sh
+dracut_SCRIPTS = dist/dracut/module-setup.sh dist/dracut/tpm2-totp.sh
 endif # HAVE_PLYMOUTH
 endif # HAVE_DRACUT
 EXTRA_DIST += dist/dracut/tpm2-totp.sh

--- a/configure.ac
+++ b/configure.ac
@@ -127,6 +127,17 @@ AM_CONDITIONAL(HAVE_DRACUT, [test -n "$with_dracutmodulesdir" -a "x$with_dracutm
 AM_COND_IF([HAVE_DRACUT], [AC_SUBST([dracutdir], [$with_dracutmodulesdir/70tpm2-totp])])
 AC_CONFIG_FILES([dist/dracut/module-setup.sh])
 
+AC_CHECK_PROG([lsinitramfs], [lsinitramfs], [yes])
+AC_ARG_WITH([initramfstoolsdir],
+            AS_HELP_STRING([--with-initramfstoolsdir=DIR], [directory for initramfs-tools scripts]),,
+            [AS_IF([test "x$lsinitramfs" = xyes], [with_initramfstoolsdir=$sysconfdir/initramfs-tools])])
+AM_CONDITIONAL(HAVE_INITRAMFSTOOLS, [test -n "$with_initramfstoolsdir" -a "x$with_initramfstoolsdir" != xno])
+AM_COND_IF([HAVE_INITRAMFSTOOLS],
+           [AC_SUBST([initramfstools_hooksdir], [$with_initramfstoolsdir/hooks])
+            AC_SUBST([initramfstools_scriptsdir], [$with_initramfstoolsdir/scripts/init-premount])
+])
+AC_CONFIG_FILES([dist/initramfs-tools/hooks/tpm2-totp])
+
 AC_CHECK_PROG([mkinitcpio], [mkinitcpio], [yes])
 AC_ARG_WITH([mkinitcpiodir],
             AS_HELP_STRING([--with-mkinitcpiodir=DIR], [directory for mkinitcpio hooks]),,
@@ -195,9 +206,10 @@ AC_OUTPUT
 
 AC_MSG_RESULT([
 $PACKAGE_NAME $VERSION
-    doxygen:    $DOXYGEN
-    pandoc:     $PANDOC
-    dracut:     $with_dracutmodulesdir
-    mkinitcpio: $with_mkinitcpiodir
-    plymouth:   $have_plymouth
+    doxygen:         $DOXYGEN
+    pandoc:          $PANDOC
+    dracut:          $with_dracutmodulesdir
+    initramfs-tools: $with_initramfstoolsdir
+    mkinitcpio:      $with_mkinitcpiodir
+    plymouth:        $have_plymouth
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ PKG_INSTALLDIR()
 AX_RECURSIVE_EVAL([$libexecdir], [LIBEXECDIR])
 AC_SUBST([LIBEXECDIR])
 
-AC_CONFIG_FILES([Makefile Doxyfile dist/tpm2-totp.pc dist/dracut/module-setup.sh dist/initcpio/install/tpm2-totp dist/initcpio/install/plymouth-tpm2-totp])
+AC_CONFIG_FILES([Makefile Doxyfile dist/tpm2-totp.pc])
 
 AC_ARG_ENABLE([defaultflags],
               [AS_HELP_STRING([--disable-defaultflags],
@@ -125,6 +125,7 @@ AC_ARG_WITH([dracutmodulesdir],
             [PKG_CHECK_VAR([with_dracutmodulesdir], [dracut], [dracutmodulesdir])])
 AM_CONDITIONAL(HAVE_DRACUT, [test -n "$with_dracutmodulesdir" -a "x$with_dracutmodulesdir" != xno])
 AM_COND_IF([HAVE_DRACUT], [AC_SUBST([dracutdir], [$with_dracutmodulesdir/70tpm2-totp])])
+AC_CONFIG_FILES([dist/dracut/module-setup.sh])
 
 AC_CHECK_PROG([mkinitcpio], [mkinitcpio], [yes])
 AC_ARG_WITH([mkinitcpiodir],
@@ -135,6 +136,7 @@ AM_COND_IF([HAVE_MKINITCPIO],
            [AC_SUBST([initcpio_installdir], [$with_mkinitcpiodir/install])
             AC_SUBST([initcpio_hooksdir], [$with_mkinitcpiodir/hooks])
            ])
+AC_CONFIG_FILES([dist/initcpio/install/tpm2-totp dist/initcpio/install/plymouth-tpm2-totp])
 
 AC_ARG_ENABLE([plymouth],
               AS_HELP_STRING([--disable-plymouth], [Disable plymouth support]))

--- a/dist/initramfs-tools/hooks/tpm2-totp.in
+++ b/dist/initramfs-tools/hooks/tpm2-totp.in
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+PREREQ='plymouth'
+prereqs() {
+    echo "$PREREQ"
+}
+
+case $1 in
+    prereqs)
+        prereqs
+        exit 0
+        ;;
+esac
+
+. /usr/share/initramfs-tools/hook-functions
+
+copy_exec @LIBEXECDIR@/plymouth-tpm2-totp /bin
+copy_exec @TSS2_TCTI_DEVICE_LIBDIR@/libtss2-tcti-device.so
+copy_modules_dir kernel/drivers/char/tpm

--- a/dist/initramfs-tools/scripts/init-premount/tpm2-totp
+++ b/dist/initramfs-tools/scripts/init-premount/tpm2-totp
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+PREREQ='plymouth'
+prereqs() {
+    echo "$PREREQ"
+}
+
+case $1 in
+    prereqs)
+        prereqs
+        exit 0
+        ;;
+esac
+
+for arg in $(cat /proc/cmdline); do
+    case "$arg" in
+        rd.tpm2-totp.nvindex=*)
+            nvindex="${arg#rd.tpm2-totp.nvindex=}"
+            ;;
+    esac
+done
+
+TSS2_LOG=tcti+error /bin/plymouth-tpm2-totp ${nvindex:+--nvindex "$nvindex"} &


### PR DESCRIPTION
Add scripts for [initramfs-tools](https://wiki.debian.org/initramfs-tools) to display the TOTP during boot on Debian/Ubuntu/Linux Mint/... Since I don't have one of these distributions installed on bare metal, I used an initrd generated in a virtual machine running Debian 10 Buster, so this isn't extremely well tested. I verified that all necessary files are included in the initrd, that the TOTP gets displayed during boot (on my physical machine) and that the `rd.tpm2-totp.nvindex` kernel command line option works as expected.

Closes: #41