### PR TITLE
Documentation updates

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,8 @@
 * pkg-config
 * tpm2-tss >= 2.0
 * libqrencode
-* pandoc
+* pandoc (optional, for man pages)
+* doxygen (optional, for man pages)
 * plymouth header files (optional, for initramfs integration)
 
 For the integration test suite:
@@ -32,6 +33,7 @@ sudo apt -y install \
   pkg-config \
   libqrencode-dev \
   pandoc \
+  doxygen \
   liboath-dev \
   iproute2 \
   plymouth \

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,6 +11,7 @@
 * tpm2-tss >= 2.0
 * libqrencode
 * pandoc
+* plymouth header files (optional, for initramfs integration)
 
 For the integration test suite:
 * liboath
@@ -32,7 +33,9 @@ sudo apt -y install \
   libqrencode-dev \
   pandoc \
   liboath-dev \
-  iproute2
+  iproute2 \
+  plymouth \
+  libplymouth-dev
 git clone --depth=1 http://www.github.com/tpm2-software/tpm2-tss
 cd tpm2-tss
 ./bootstrap
@@ -68,6 +71,14 @@ In order to link against a developer version of tpm2-tss (not installed):
   CFLAGS=-I${TPM2TSS}/include \
   LDFLAGS=-L${TPM2TSS}/src/tss2-{tcti,mu,sys,esys}/.libs
 ```
+
+# initramfs-tools and mkinitcpio integration
+To make sure that the hooks get installed to the correct directory, either use
+```
+./configure --sysconfdir=/etc
+```
+or set the correct directory directly with the `--with-initramfstoolsdir`/
+`--with-mkinitcpiodir` configuration option.
 
 # Post installation
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -182,9 +182,10 @@ endif # HAVE_DOXYGEN
 if HAVE_DRACUT
 if HAVE_PLYMOUTH
 dracut_SCRIPTS = dist/dracut/module-setup.sh dist/dracut/tpm2-totp.sh
+dracut_DATA = dist/dracut/README
 endif # HAVE_PLYMOUTH
 endif # HAVE_DRACUT
-EXTRA_DIST += dist/dracut/tpm2-totp.sh
+EXTRA_DIST += dist/dracut/tpm2-totp.sh dist/dracut/README
 
 if HAVE_INITRAMFSTOOLS
 if HAVE_PLYMOUTH

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ Followed by setting up the initrd, see below.
 Instructions on packages needed to build and install tpm2-totp and different
 build options are available in the [INSTALL](INSTALL.md) file.
 
+# Initramfs integration
+The project includes hooks for [dracut](https://dracut.wiki.kernel.org/),
+[initramfs-tools](https://wiki.debian.org/initramfs-tools) and
+[mkinitcpio](https://wiki.archlinux.org/index.php/Mkinitcpio) to display
+the TOTP during boot using [Plymouth](https://www.freedesktop.org/wiki/Software/Plymouth/).
+They are automatically installed if the corresponding tool is found on the
+system (also see [INSTALL](INSTALL.md) regarding necessary configuration
+options). To use them, install tpm2-totp and generate a TOTP secret, then enable
+the tpm2-totp hook in your initramfs generator and rebuild the initramfs.
+
 # Usage
 
 ## Setup

--- a/dist/dracut/README
+++ b/dist/dracut/README
@@ -1,0 +1,22 @@
+This dracut module displays a time-based one-time password (TOTP) sealed to a
+Trusted Platform Module (TPM) to ensure that the boot process has not been
+tampered with. To set this up, a secret needs to be generated first and sealed
+to the TPM using 'tpm2-totp generate'.
+
+This stores the secret in the TPM and displays it to the user so that it can
+be recorded on a different device (e.g. a TOTP app). When the hook is run, the
+TOTP is calculated and displayed together with the current time so that it can
+be compared with the output of the second device. This will only be successful
+and show a matching output if the boot process has not changed (new UEFI
+firmware, different boot loader, ...).
+
+When using a custom NV index with the '--nvindex index' option of tpm2-totp,
+this index needs to be specified as 'rd.tpm2totp.nvindex=index' on the kernel
+command line.
+
+Note that calculating the TOTP requires some entropy, which might be scarce
+directly after startup. If the boot process appears to be stuck, it might help
+to press some random keys to gather more entropy. A better alternative on modern
+processors is to enable the use of the hardware random number generator (RNG)
+by adding 'random.trust_cpu=on' to the kernel command line or by loading the
+'rngd' dracut module.


### PR DESCRIPTION
- Mention the initramfs hooks in [README](https://github.com/tpm2-software/tpm2-totp/blob/master/README.md) and in [INSTALL](https://github.com/tpm2-software/tpm2-totp/blob/master/INSTALL.md) so that people know that they exist and how to install them.
- The new [tpm2-totp(3) man page](https://github.com/tpm2-software/tpm2-totp/pull/42) optionally requires doxygen during build.
- Add a README to the dracut module because that seems to be common practice. The text is largely taken from the [help text of the mkinitcpio hook](https://github.com/tpm2-software/tpm2-totp/blob/master/dist/initcpio/install/tpm2-totp.in).