### PR TITLE
src: replace localtime by localtime_r

### DIFF
--- a/src/plymouth-tpm2-totp.c
+++ b/src/plymouth-tpm2-totp.c
@@ -143,6 +143,7 @@ display_totp(state_t *state, ply_event_loop_t *event_loop)
     int rc;
     uint64_t totp;
     time_t now;
+    struct tm now_local;
     char timestr[30] = "";
     char totpstr[40] = "";
 
@@ -151,7 +152,8 @@ display_totp(state_t *state, ply_event_loop_t *event_loop)
 
     if (rc == TSS2_RC_SUCCESS) {
         if (opt.time) {
-            if (strftime(timestr, sizeof(timestr)-1, "%F %T: ", localtime(&now)) == 0) {
+            localtime_r(&now, &now_local);
+            if (strftime(timestr, sizeof(timestr)-1, "%F %T: ", &now_local) == 0) {
                 timestr[0] = '\0';
             }
         }

--- a/src/tpm2-totp.c
+++ b/src/tpm2-totp.c
@@ -314,6 +314,7 @@ main(int argc, char **argv)
     char *base32key, *url, *qrpic;
     uint64_t totp;
     time_t now;
+    struct tm now_local;
     char timestr[100] = { 0, };
     TSS2_TCTI_CONTEXT *tcti_context;
 
@@ -359,8 +360,9 @@ main(int argc, char **argv)
         free(keyBlob);
         chkrc(rc, goto err);
         if (opt.time) {
-            rc = !strftime (timestr, sizeof(timestr)-1, "%Y-%m-%d %H:%M:%S: ",
-                            localtime (&now));
+            localtime_r(&now, &now_local);
+            rc = !strftime(timestr, sizeof(timestr)-1, "%Y-%m-%d %H:%M:%S: ",
+                           &now_local);
             chkrc(rc, goto err);
         }
         printf("%s%06" PRIu64, timestr, totp);


### PR DESCRIPTION
Fix the alerts reported by [LGTM](https://lgtm.com/projects/g/tpm2-software/tpm2-totp/snapshot/25e778746b1774d3b549e066f36362da34f98ba3/files/src/plymouth-tpm2-totp.c#x23c0813f6532bb09:1): using the reentrant version of standard library functions is generally safer (though not strictly necessary since we are not using multithreading at the moment).