### PR TITLE
dist: remove TSS2_LOG=tcti+error

### DIFF
--- a/dist/dracut/tpm2-totp.sh
+++ b/dist/dracut/tpm2-totp.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 . /lib/dracut-lib.sh
 nvindex="$(getarg rd.tpm2-totp.nvindex)"
-export TSS2_LOG
-printf 'KERNEL=="tpm0", RUN+="/sbin/initqueue --settled --onetime --env TSS2_LOG=tcti+error /bin/plymouth-tpm2-totp %s &"\n' "${nvindex:+--nvindex "$nvindex"}" > /etc/udev/rules.d/80-tpm2-totp.rules
+printf 'KERNEL=="tpm0", RUN+="/sbin/initqueue --settled --onetime /bin/plymouth-tpm2-totp %s &"\n' "${nvindex:+--nvindex "$nvindex"}" > /etc/udev/rules.d/80-tpm2-totp.rules
 unset nvindex

--- a/dist/initcpio/hooks/plymouth-tpm2-totp
+++ b/dist/initcpio/hooks/plymouth-tpm2-totp
@@ -1,7 +1,7 @@
 #!/usr/bin/ash
 
 run_hook() {
-    TSS2_LOG=tcti+error plymouth-tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} &
+    plymouth-tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} &
 }
 
 # vim: set ft=sh ts=4 sw=4 et:

--- a/dist/initcpio/hooks/tpm2-totp
+++ b/dist/initcpio/hooks/tpm2-totp
@@ -2,10 +2,10 @@
 
 run_hook() {
     echo 'Verify the TOTP (press any key to continue):'
-    TSS2_LOG=tcti+error tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} --time calculate
+    tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} --time calculate
     echo
     while ! read -n 1 -r -s -t 10; do
-        TSS2_LOG=tcti+error tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} --time calculate
+        tpm2-totp ${tpm2_totp_nvindex:+--nvindex "$tpm2_totp_nvindex"} --time calculate
         echo
     done
 }

--- a/dist/initramfs-tools/scripts/init-premount/tpm2-totp
+++ b/dist/initramfs-tools/scripts/init-premount/tpm2-totp
@@ -20,4 +20,4 @@ for arg in $(cat /proc/cmdline); do
     esac
 done
 
-TSS2_LOG=tcti+error /bin/plymouth-tpm2-totp ${nvindex:+--nvindex "$nvindex"} &
+/bin/plymouth-tpm2-totp ${nvindex:+--nvindex "$nvindex"} &


### PR DESCRIPTION
Since tpm2-tss 2.3.0 (https://github.com/tpm2-software/tpm2-tss/commit/727fc47ea15941c29bac993c39fb1d2e5987f9ac) messages about missing TCTI libraries like libtss2-tcti-default.so have log level DEBUG and are therefore hidden from the logging output by default, hence we can remove our custom log level setting. Since #53 we only support tpm2-tss>=2.3 anyway, so backwards compatibility is not a concern here.