### PR TITLE
tpm2-totp: fix segfault for invalid command line arguments

### DIFF
--- a/src/tpm2-totp.c
+++ b/src/tpm2-totp.c
@@ -304,10 +304,6 @@ qrencode(const char *url)
 int
 main(int argc, char **argv)
 {
-    if (parse_opts(argc, argv) != 0) {
-        goto err;
-    }
-
     int rc;
     uint8_t *secret, *keyBlob, *newBlob;
     size_t secret_size, keyBlob_size, newBlob_size;
@@ -316,7 +312,11 @@ main(int argc, char **argv)
     time_t now;
     struct tm now_local;
     char timestr[100] = { 0, };
-    TSS2_TCTI_CONTEXT *tcti_context;
+    TSS2_TCTI_CONTEXT *tcti_context = NULL;
+
+    if (parse_opts(argc, argv) != 0) {
+        goto err;
+    }
 
     if (!opt.tcti) {
         opt.tcti = getenv(TPM2TOTP_ENV_TCTI);

--- a/test/tpm2-totp.sh
+++ b/test/tpm2-totp.sh
@@ -5,6 +5,13 @@
 
 set -eufx
 
+exit_status=0
+tpm2-totp invalid-argument || exit_status=$?
+if [ "$exit_status" -ne 1 ]; then
+	echo "tpm2-totp should have exit status 1 on invalid arguments!"
+	exit 1
+fi
+
 tpm2-totp -P abc -p 0,1,2,3,4,5,6 -b SHA1,SHA256 generate
 
 # Changing an unselected PCR bank should not affect the TOTP calculation


### PR DESCRIPTION
`tcti_context` needs to be initialised so that `Tss2_TctiLdr_Finalize` can be called safely in case of errors. Also add an integration test with an invalid argument to catch this issue in the future.