### PR TITLE
build: fix doxygen status display in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -197,7 +197,7 @@ AC_OUTPUT
 
 AC_MSG_RESULT([
 $PACKAGE_NAME $VERSION
-    doxygen:         $DOXYGEN
+    doxygen:         $DX_DOXYGEN
     pandoc:          $PANDOC
     dracut:          $with_dracutmodulesdir
     initramfs-tools: $with_initramfstoolsdir


### PR DESCRIPTION
The variable name was wrong, resulting in an empty display at all times:
```
tpm2-totp 0.2.0_rc0
    doxygen:         
    pandoc:          /usr/bin/pandoc
    dracut:          /usr/lib/dracut/modules.d
    initramfs-tools: 
    mkinitcpio:      ${prefix}/etc/initcpio
    plymouth:        yes
```