### PR TITLE
build: install dracut module if plymouth is not available

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -201,7 +201,4 @@ initcpio_install_DATA += dist/initcpio/install/plymouth-tpm2-totp
 initcpio_hooks_DATA += dist/initcpio/hooks/plymouth-tpm2-totp
 endif # HAVE_PLYMOUTH
 endif # HAVE_MKINITCPIO
-EXTRA_DIST += \
-	dist/initcpio/install/tpm2-totp \
-	dist/initcpio/hooks/tpm2-totp \
-	dist/initcpio/hooks/plymouth-tpm2-totp
+EXTRA_DIST += dist/initcpio/hooks/tpm2-totp dist/initcpio/hooks/plymouth-tpm2-totp

--- a/Makefile.am
+++ b/Makefile.am
@@ -178,11 +178,9 @@ endif # HAVE_DOXYGEN
 EXTRA_DIST += dist/show-tpm2-totp
 
 if HAVE_DRACUT
-if HAVE_PLYMOUTH
 dracut_SCRIPTS = dist/dracut/module-setup.sh dist/dracut/show-tpm2-totp.sh \
                  dist/dracut/cleanup-tpm2-totp.sh dist/show-tpm2-totp
 dracut_DATA = dist/dracut/README
-endif # HAVE_PLYMOUTH
 endif # HAVE_DRACUT
 EXTRA_DIST += dist/dracut/show-tpm2-totp.sh dist/dracut/cleanup-tpm2-totp.sh dist/dracut/README
 

--- a/dist/dracut/module-setup.sh.in
+++ b/dist/dracut/module-setup.sh.in
@@ -13,7 +13,8 @@ check() {
 
 install() {
     inst_libdir_file 'libtss2-tcti-device.so*'
-    if dracut_module_included "plymouth"; then
+    if dracut_module_included "plymouth" && \
+       find_binary @HELPERSDIR@/plymouth-tpm2-totp; then
         inst @HELPERSDIR@/plymouth-tpm2-totp /bin/show-tpm2-totp
         inst_library @PLYMOUTHPLUGINSDIR@/label.so
         inst_simple "$(fc-match --format '%{file}')"


### PR DESCRIPTION
Since commit 38ca58575fc7b964e60e30457859020df2ba0fe6 the dracut module works without plymouth as well, so install it whenever dracut is available.

`plymouth-tpm2-totp` might not be available even if plymouth is installed if tpm2-totp was built on a system without plymouth. Fall back to the version without plymouth in this case, which is guaranteed to exist if the dracut module is installed. In this case the TOTP is not shown in the graphical boot screen, but can be seen after pressing the <kbd>Esc</kbd> key.

Also remove `dist/initcpio/install/tpm2-totp` from the distribution tarball because it is autogenerated from [`dist/initcpio/install/tpm2-totp.in`](https://github.com/tpm2-software/tpm2-totp/blob/master/dist/initcpio/install/tpm2-totp.in).