### PR TITLE
dist: fix installation location of show-tpm2-totp for dracut

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -178,8 +178,9 @@ endif # HAVE_DOXYGEN
 EXTRA_DIST += dist/show-tpm2-totp
 
 if HAVE_DRACUT
+helpers_SCRIPTS = dist/show-tpm2-totp
 dracut_SCRIPTS = dist/dracut/module-setup.sh dist/dracut/show-tpm2-totp.sh \
-                 dist/dracut/cleanup-tpm2-totp.sh dist/show-tpm2-totp
+                 dist/dracut/cleanup-tpm2-totp.sh
 dracut_DATA = dist/dracut/README
 endif # HAVE_DRACUT
 EXTRA_DIST += dist/dracut/show-tpm2-totp.sh dist/dracut/cleanup-tpm2-totp.sh dist/dracut/README


### PR DESCRIPTION
`module-setup.sh` [copies `show-tpm2-totp` from `helpersdir`](https://github.com/tpm2-software/tpm2-totp/blob/b3efaec7266b2c8717dc7107b941d8284a67cd62/dist/dracut/module-setup.sh.in#L22), so the script needs to be put there (as [it is done for mkinitcpio](https://github.com/tpm2-software/tpm2-totp/blob/b3efaec7266b2c8717dc7107b941d8284a67cd62/Makefile.am#L196) as well) instead of `dracutdir`.