### PR TITLE
src/libtpm2-totp.c: include <endian.h>

### DIFF
--- a/src/libtpm2-totp.c
+++ b/src/libtpm2-totp.c
@@ -8,6 +8,7 @@
 
 #include <tpm2-totp.h>
 
+#include <endian.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Fix the following build failure with musl:

```
src/libtpm2-totp.c: In function ‘tpm2totp_calculate’:
src/libtpm2-totp.c:826:11: warning: implicit declaration of function ‘htobe64’ [-Wimplicit-function-declaration]
     tmp = htobe64(tmp);
           ^~~~~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>