### PR TITLE
dist: escape "$" in dracut udev rule

### DIFF
--- a/dist/dracut/show-tpm2-totp.sh
+++ b/dist/dracut/show-tpm2-totp.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 . /lib/dracut-lib.sh
 nvindex="$(getarg rd.tpm2-totp.nvindex)"
-printf 'KERNEL=="tpm0", RUN+="/sbin/initqueue --settled --onetime /bin/show-tpm2-totp %s & show_tpm2_totp_pid=$!"\n' "${nvindex:+--nvindex "$nvindex"}" > /etc/udev/rules.d/80-tpm2-totp.rules
+printf 'KERNEL=="tpm0", RUN+="/sbin/initqueue --settled --onetime /bin/show-tpm2-totp %s & show_tpm2_totp_pid=$$!"\n' "${nvindex:+--nvindex "$nvindex"}" > /etc/udev/rules.d/80-tpm2-totp.rules
 unset nvindex


### PR DESCRIPTION
The dollar sign is a [special character in udev rules](https://www.freedesktop.org/software/systemd/man/udev.html#Rules%20Files) and must be escaped as `$$`, otherwise `journalctl -b` shows the following warning:
```
/etc/udev/rules.d/80-tpm2-totp.rules:1 Invalid value "/sbin/initqueue --settled --onetime /bin/show-tpm2-totp & show_tpm2_totp_pid=$!" for RUN (char 79: invalid substitution type),ignoring, but please fix it.
```
This hopefully fixes #65.