### PR TITLE
Include hostname and use 1/4 size unicode block characters

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -65,29 +65,19 @@ endif
 @DX_RULES@
 MOSTLYCLEANFILES += $(DX_CLEANFILES)
 
-### Library ###
-lib_LTLIBRARIES += libtpm2-totp.la
-include_HEADERS += include/tpm2-totp.h
-
-libtpm2_totp_la_SOURCES = src/libtpm2-totp.c
-libtpm2_totp_la_LIBADD = $(AM_LDADD)
-libtpm2_totp_la_LDFLAGS = $(AM_LDFLAGS) '(tpm2_totp)'
-
-pkgconfig_DATA = dist/tpm2-totp.pc
-
 ### Executable ###
 bin_PROGRAMS += tpm2-totp
 
-tpm2_totp_SOURCES = src/tpm2-totp.c
+tpm2_totp_SOURCES = src/tpm2-totp.c src/libtpm2-totp.c
 tpm2_totp_CFLAGS = $(AM_CFLAGS) $(TSS2_TCTILDR_CFLAGS) $(QRENCODE_CFLAGS)
-tpm2_totp_LDADD = $(AM_LDADD) $(TSS2_TCTILDR_LIBS) $(QRENCODE_LIBS) -ldl libtpm2-totp.la
+tpm2_totp_LDADD = $(AM_LDADD) $(TSS2_TCTILDR_LIBS) $(QRENCODE_LIBS)
 tpm2_totp_LDFLAGS = $(AM_LDFLAGS)
 
 if HAVE_PLYMOUTH
 helpers_PROGRAMS += plymouth-tpm2-totp
-plymouth_tpm2_totp_SOURCES = src/plymouth-tpm2-totp.c
+plymouth_tpm2_totp_SOURCES = src/plymouth-tpm2-totp.c src/libtpm2-totp.c
 plymouth_tpm2_totp_CFLAGS = $(AM_CFLAGS) $(TSS2_TCTILDR_CFLAGS) $(PLY_BOOT_CLIENT_CFLAGS)
-plymouth_tpm2_totp_LDADD = $(AM_LDADD) $(TSS2_TCTILDR_LIBS) $(PLY_BOOT_CLIENT_LIBS) -ldl libtpm2-totp.la
+plymouth_tpm2_totp_LDADD = $(AM_LDADD) $(TSS2_TCTILDR_LIBS) $(PLY_BOOT_CLIENT_LIBS)
 plymouth_tpm2_totp_LDFLAGS = $(AM_LDFLAGS)
 endif # HAVE_PLYMOUTH
 


### PR DESCRIPTION
This patch adds an argument for `--label` to change the machine name from `TPM2-TOTP` to whatever the user wants.  If you have multiple machines used with totp, it's nice to know which is which.

It also replaces the ANSI escape sequences with unicode block drawings that pack 4 bits in a single character, so the entire QR code fits on a single terminal window more easily.

There is also a small tweak to directly link `libtpm2-totp.c` into the binaries, which makes it easier to include in some systems.