### PR TITLE
test: add support for swtpm simulator

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -16,7 +16,7 @@
 
 For the integration test suite:
 * liboath
-* tpm_server
+* [swtpm](https://github.com/stefanberger/swtpm) or [tpm_server](https://sourceforge.net/projects/ibmswtpm2/)
 * realpath
 * ss
 

--- a/configure.ac
+++ b/configure.ac
@@ -167,9 +167,10 @@ AC_ARG_ENABLE([integration],
 AM_CONDITIONAL([INTEGRATION], [test "x$enable_integration" != xno])
 AS_IF([test "x$enable_integration" != xno],
       [PKG_CHECK_MODULES([OATH],[liboath])
+       AC_CHECK_PROG([swtpm], [swtpm], [yes])
        AC_CHECK_PROG([tpm_server], [tpm_server], [yes])
-       AS_IF([test "x$tpm_server" != xyes],
-             [AC_MSG_ERROR([Integration tests require the tpm_server executable])])
+       AS_IF([test "x$swtpm" != xyes && test "x$tpm_server" != xyes],
+             [AC_MSG_ERROR([Integration tests require either the swtpm or the tpm_server executable])])
        AC_CHECK_PROG([realpath], [realpath], [yes])
        AS_IF([test "x$realpath" != xyes],
              [AC_MSG_ERROR([Integration tests require the realpath executable])])

--- a/test/sh_log_compiler.sh
+++ b/test/sh_log_compiler.sh
@@ -12,21 +12,34 @@ tmp_dir="$(mktemp --directory)"
 echo "Switching to temporary directory $tmp_dir"
 cd "$tmp_dir"
 
+for simulator in 'swtpm' 'tpm_server'; do
+    simulator_binary="$(command -v "$simulator")" && break
+done
+if [ -z "$simulator_binary" ]; then
+    echo 'ERROR: No TPM simulator was found on PATH'
+    exit 99
+fi
+
 for attempt in $(seq 9 -1 0); do
-    tpm_server_port="$(shuf --input-range 1024-65534 --head-count 1)"
-    echo "Starting simulator on port $tpm_server_port"
-    tpm_server -port "$tpm_server_port" &
-    tpm_server_pid="$!"
+    simulator_port="$(shuf --input-range 1024-65534 --head-count 1)"
+    echo "Starting simulator on port $simulator_port"
+    case "$simulator_binary" in
+        *swtpm) "$simulator_binary" socket --tpm2 --server port="$simulator_port" \
+                                           --ctrl type=tcp,port="$(( simulator_port + 1 ))" \
+                                           --flags not-need-init --tpmstate dir="$tmp_dir" &;;
+        *tpm_server) "$simulator_binary" -port "$simulator_port" &;;
+    esac
+    simulator_pid="$!"
     sleep 1
 
-    if ( ss --listening --tcp --ipv4 --processes | grep "$tpm_server_pid" | grep --quiet "$tpm_server_port" &&
-         ss --listening --tcp --ipv4 --processes | grep "$tpm_server_pid" | grep --quiet "$(( tpm_server_port + 1 ))" )
+    if ( ss --listening --tcp --ipv4 --processes | grep "$simulator_pid" | grep --quiet "$simulator_port" &&
+         ss --listening --tcp --ipv4 --processes | grep "$simulator_pid" | grep --quiet "$(( simulator_port + 1 ))" )
     then
-        echo "Simulator with PID $tpm_server_pid started successfully"
+        echo "Simulator with PID $simulator_pid started successfully"
         break
     else
         echo "Failed to start simulator, the port might be in use"
-        kill "$tpm_server_pid"
+        kill "$simulator_pid"
 
         if [ "$attempt" -eq 0 ]; then
             echo 'ERROR: Reached maximum number of tries to start simulator, giving up'
@@ -35,7 +48,10 @@ for attempt in $(seq 9 -1 0); do
     fi
 done
 
-export TPM2TOTP_TCTI="mssim:port=$tpm_server_port"
+case "$simulator_binary" in
+    *swtpm) export TPM2TOTP_TCTI="swtpm:port=$simulator_port";;
+    *tpm_server) export TPM2TOTP_TCTI="mssim:port=$simulator_port";;
+esac
 export TPM2TOOLS_TCTI="$TPM2TOTP_TCTI"
 
 tpm2_startup --clear
@@ -44,7 +60,7 @@ echo "Starting $test_script"
 "$test_script"
 test_status="$?"
 
-kill "$tpm_server_pid"
+kill "$simulator_pid"
 rm -rf "$tmp_dir"
 
 exit "$test_status"


### PR DESCRIPTION
`libtss2-tcti-swtpm` is available in tpm2-tss 3.0.0. Keep support for `libtss2-tcti-mssim` to allow running the integration tests with older tpm2-tss versions as well, but prefer swtpm if it is available.