### PR TITLE
tpm2-totp: display more specific messages for common error cases

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,14 +80,14 @@ bin_PROGRAMS += tpm2-totp
 
 tpm2_totp_SOURCES = src/tpm2-totp.c
 tpm2_totp_CFLAGS = $(AM_CFLAGS) $(TSS2_TCTILDR_CFLAGS) $(QRENCODE_CFLAGS)
-tpm2_totp_LDADD = $(AM_LDADD) $(TSS2_TCTILDR_LIBS) $(QRENCODE_LIBS) -ldl libtpm2-totp.la
+tpm2_totp_LDADD = $(AM_LDADD) $(TSS2_TCTILDR_LIBS) $(QRENCODE_LIBS) libtpm2-totp.la
 tpm2_totp_LDFLAGS = $(AM_LDFLAGS)
 
 if HAVE_PLYMOUTH
 helpers_PROGRAMS += plymouth-tpm2-totp
 plymouth_tpm2_totp_SOURCES = src/plymouth-tpm2-totp.c
 plymouth_tpm2_totp_CFLAGS = $(AM_CFLAGS) $(TSS2_TCTILDR_CFLAGS) $(PLY_BOOT_CLIENT_CFLAGS)
-plymouth_tpm2_totp_LDADD = $(AM_LDADD) $(TSS2_TCTILDR_LIBS) $(PLY_BOOT_CLIENT_LIBS) -ldl libtpm2-totp.la
+plymouth_tpm2_totp_LDADD = $(AM_LDADD) $(TSS2_TCTILDR_LIBS) $(PLY_BOOT_CLIENT_LIBS) libtpm2-totp.la
 plymouth_tpm2_totp_LDFLAGS = $(AM_LDFLAGS)
 endif # HAVE_PLYMOUTH
 
@@ -114,7 +114,7 @@ check_PROGRAMS += libtpm2-totp
 
 libtpm2_totp_SOURCES = test/libtpm2-totp.c
 libtpm2_totp_CFLAGS = $(AM_CFLAGS) $(TSS2_TCTILDR_CFLAGS) $(OATH_CFLAGS)
-libtpm2_totp_LDADD = $(AM_LDADD)  $(TSS2_TCTILDR_LIBS) $(OATH_LIBS) -ldl libtpm2-totp.la
+libtpm2_totp_LDADD = $(AM_LDADD) $(TSS2_TCTILDR_LIBS) $(OATH_LIBS) libtpm2-totp.la
 libtpm2_totp_LDFLAGS = $(AM_LDFLAGS) $(OATH_LDFLAGS)
 endif #INTEGRATION
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -79,8 +79,8 @@ pkgconfig_DATA = dist/tpm2-totp.pc
 bin_PROGRAMS += tpm2-totp
 
 tpm2_totp_SOURCES = src/tpm2-totp.c
-tpm2_totp_CFLAGS = $(AM_CFLAGS) $(TSS2_TCTILDR_CFLAGS) $(QRENCODE_CFLAGS)
-tpm2_totp_LDADD = $(AM_LDADD) $(TSS2_TCTILDR_LIBS) $(QRENCODE_LIBS) libtpm2-totp.la
+tpm2_totp_CFLAGS = $(AM_CFLAGS) $(TSS2_TCTILDR_CFLAGS) $(TSS2_RC_CFLAGS) $(QRENCODE_CFLAGS)
+tpm2_totp_LDADD = $(AM_LDADD) $(TSS2_TCTILDR_LIBS) $(TSS2_RC_LIBS) $(QRENCODE_LIBS) libtpm2-totp.la
 tpm2_totp_LDFLAGS = $(AM_LDFLAGS)
 
 if HAVE_PLYMOUTH

--- a/configure.ac
+++ b/configure.ac
@@ -89,6 +89,7 @@ PKG_PROG_PKG_CONFIG([0.25])
 PKG_CHECK_MODULES([TSS2_ESYS],[tss2-esys])
 PKG_CHECK_MODULES([TSS2_MU],[tss2-mu])
 PKG_CHECK_MODULES([TSS2_TCTILDR],[tss2-tctildr])
+PKG_CHECK_MODULES([TSS2_RC],[tss2-rc])
 PKG_CHECK_VAR([TSS2_TCTI_DEVICE_LIBDIR], [tss2-tcti-device], [libdir], ,
               [AC_MSG_ERROR([Required library tss2-tcti-device not found])])
 AC_SUBST([TSS2_TCTI_DEVICE_LIBDIR])

--- a/src/libtpm2-totp.c
+++ b/src/libtpm2-totp.c
@@ -106,6 +106,7 @@ TPM2B_AUTH emptyAuth = { .size = 0, };
  * @param[out] keyBlob_size Size of the generated key.
  * @retval 0 on success.
  * @retval -1 on undefined/general failure.
+ * @retval TSS2_RC response code for failures relayed from the TSS library.
  */
 int
 tpm2totp_generateKey(uint32_t pcrs, uint32_t banks, const char *password,
@@ -319,6 +320,8 @@ error:
  * @retval 0 on success.
  * @retval -1 on undefined/general failure.
  * @retval -10 on empty password.
+ * @retval -20 when no password-protected recovery copy of the secret has been stored.
+ * @retval TSS2_RC response code for failures relayed from the TSS library.
  */
 int
 tpm2totp_reseal(const uint8_t *keyBlob, size_t keyBlob_size,
@@ -395,7 +398,7 @@ tpm2totp_reseal(const uint8_t *keyBlob, size_t keyBlob_size,
 
     if (off == keyBlob_size) {
         dbg("No unseal blob included.");
-        return -1;
+        return -20;
     }
 
     rc = Tss2_MU_TPM2B_PUBLIC_Unmarshal(keyBlob, keyBlob_size, &off,
@@ -544,6 +547,7 @@ error:
  * @param[in] tcti_context Optional TCTI context to select TPM to use.
  * @retval 0 on success.
  * @retval -1 on undefined/general failure.
+ * @retval TSS2_RC response code for failures relayed from the TSS library.
  */
 int
 tpm2totp_storeKey_nv(const uint8_t *keyBlob, size_t keyBlob_size, uint32_t nv,
@@ -614,6 +618,7 @@ error:
  * @param[out] keyBlob_size Size of the key.
  * @retval 0 on success.
  * @retval -1 on undefined/general failure.
+ * @retval TSS2_RC response code for failures relayed from the TSS library.
  */
 int
 tpm2totp_loadKey_nv(uint32_t nv, TSS2_TCTI_CONTEXT *tcti_context,
@@ -671,6 +676,7 @@ error:
  * @param[in] tcti_context Optional TCTI context to select TPM to use.
  * @retval 0 on success.
  * @retval -1 on undefined/general failure.
+ * @retval TSS2_RC response code for failures relayed from the TSS library.
  */
 int
 tpm2totp_deleteKey_nv(uint32_t nv, TSS2_TCTI_CONTEXT *tcti_context)
@@ -716,6 +722,7 @@ error:
  * @param[out] otp Calculated TOTP.
  * @retval 0 on success.
  * @retval -1 on undefined/general failure.
+ * @retval TSS2_RC response code for failures relayed from the TSS library.
  */
 int
 tpm2totp_calculate(const uint8_t *keyBlob, size_t keyBlob_size,
@@ -872,6 +879,8 @@ error:
  * @retval 0 on success.
  * @retval -1 on undefined/general failure.
  * @retval -10 on empty password.
+ * @retval -20 when no password-protected recovery copy of the secret has been stored.
+ * @retval TSS2_RC response code for failures relayed from the TSS library.
  */
 int
 tpm2totp_getSecret(const uint8_t *keyBlob, size_t keyBlob_size,
@@ -905,7 +914,7 @@ tpm2totp_getSecret(const uint8_t *keyBlob, size_t keyBlob_size,
 
     if (off == keyBlob_size) {
         dbg("No unseal blob included.");
-        return -1;
+        return -20;
     }
 
     rc = Tss2_MU_TPM2B_PUBLIC_Unmarshal(keyBlob, keyBlob_size, &off, &keyPublic);

--- a/src/libtpm2-totp.c
+++ b/src/libtpm2-totp.c
@@ -27,10 +27,13 @@
 
 const TPM2B_DIGEST ownerauth = { .size = 0 };
 
+#ifdef NDEBUG
+#define dbg(m, ...)
+#else
 #define dbg(m, ...) fprintf(stderr, m "\n", ##__VA_ARGS__)
+#endif
 
-#define chkrc(rc, cmd) if (rc != TSS2_RC_SUCCESS) {\
-    dbg("ERROR in %s (%s:%i): 0x%08x\n", __func__, __FILE__, __LINE__, rc); cmd; }
+#define chkrc(rc, cmd) if (rc != TSS2_RC_SUCCESS) { cmd; }
 
 #define TPM2B_PUBLIC_PRIMARY_TEMPLATE { .size = 0, \
     .publicArea = { \


### PR DESCRIPTION
I thought I had submitted this ages ago, but apparently I didn't... Add some custom error messages for frequent problems like trying to call `tpm2-totp calculate` twice, being unable to calculate the TOTP after a change in PCRs etc. If none of the custom error messages are applicable, fall back to the messages from tss2-rc instead of displaying a raw response code.

Closes: #61