### PR TITLE
print uint64_t using inttypes.h `PRIu64` instead of `ld`

### DIFF
--- a/test/libtpm2-totp.c
+++ b/test/libtpm2-totp.c
@@ -46,7 +46,7 @@ main(int argc, char **argv)
 
     rc = tpm2totp_calculate(keyBlob, keyBlob_size, tcti_context, &now, &totp);
     chkrc(rc, goto err);
-    snprintf(&totp_string[0], 7, "%.*ld", 6, totp);
+    snprintf(&totp_string[0], 7, "%.*" PRIu64, 6, totp);
 
     rc = oath_totp_generate((char *)secret, secret_size, now, 30, 0, 6, &totp_check[0]);
     chkrc(rc, goto err);
@@ -63,7 +63,7 @@ main(int argc, char **argv)
 
     rc = tpm2totp_calculate(newBlob, newBlob_size, tcti_context, &now, &totp);
     chkrc(rc, goto err);
-    snprintf(&totp_string[0], 7, "%.*ld", 6, totp);
+    snprintf(&totp_string[0], 7, "%.*" PRIu64, 6, totp);
 
     rc = oath_totp_generate((char *)secret, secret_size, now, 30, 0, 6, &totp_check[0]);
     chkrc(rc, goto err);


### PR DESCRIPTION
The correct format specifier for uint64_t is PRIu64.

fixes these compilation issues on my rpi:
```
test/libtpm2-totp.c:49:39: error: format ‘%ld’ expects argument of type
‘long int’, but argument 5 has type ‘uint64_t’ {aka ‘long long unsigned
int’} [-Werror=format=]
     snprintf(&totp_string[0], 7, "%.*ld", 6, totp);
                                   ~~~~^      ~~~~
                                   %.*lld
test/libtpm2-totp.c:66:39: error: format ‘%ld’ expects argument of type
‘long int’, but argument 5 has type ‘uint64_t’ {aka ‘long long unsigned
int’} [-Werror=format=]
     snprintf(&totp_string[0], 7, "%.*ld", 6, totp);
                                   ~~~~^      ~~~~
                                   %.*lld
```

Signed-off-by: Peter Huewe <Peter.Huewe@infineon.com>