### PR TITLE
build: Remove bogus value from Makefile.am.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,7 @@ include_HEADERS += include/tpm2-totp.h
 
 libtpm2_totp_la_SOURCES = src/libtpm2-totp.c
 libtpm2_totp_la_LIBADD = $(AM_LDADD)
-libtpm2_totp_la_LDFLAGS = $(AM_LDFLAGS) '(tpm2_totp)'
+libtpm2_totp_la_LDFLAGS = $(AM_LDFLAGS)
 
 pkgconfig_DATA = dist/tpm2-totp.pc
 


### PR DESCRIPTION
When building tpm2-totp with slibtool (https://dev.midipix.org/cross/slibtool) it fails.
```
rdlibtool --tag=CC --mode=link clang -I./include -I./src -std=c99 -Wall -Wextra -Wformat-security -Werror -fstack-protector-all -fpic -fPIC -O2 -Wno-missing-braces -I/usr/include/tss2 -I/usr/include/tss2 -g -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,now -Wl,-z,relro (tpm2_totp) -o libtpm2-totp.la -rpath /usr/local/lib src/libtpm2-totp.lo -ltss2-esys -ltss2-mu

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/tpm2-totp"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 34, .st_ino = 375651}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = 3.
rdlibtool: lconf: found "/tmp/tpm2-totp/libtool".
rdlibtool: link: ar crs .libs/libtpm2-totp.a src/.libs/libtpm2-totp.o
rdlibtool: link: clang src/.libs/libtpm2-totp.o -I./include -I./src -std=c99 -Wall -Wextra -Wformat-security -Werror -fstack-protector-all -fpic -fPIC -O2 -Wno-missing-braces -I/usr/include/tss2 -I/usr/include/tss2 -g -Wl,--no-undefined -Wl,-z,noexecstack -Wl,-z,now -Wl,-z,relro (tpm2_totp) -ltss2-esys -ltss2-mu -shared -fPIC -Wl,-soname -Wl,libtpm2-totp.so.0 -o .libs/libtpm2-totp.so.0.0.0
clang-11: error: no such file or directory: '(tpm2_totp)'
rdlibtool: exec error upon slbt_exec_link_create_library(), line 1446: (see child process error messages).
rdlibtool: < returned to > slbt_exec_link(), line 1843.
make: *** [Makefile:1117: libtpm2-totp.la] Error 2
```
This is because `Makefile.am` contains the value `'(tpm2_totp)'` in `libtpm2_totp_la_LDFLAGS` which apparently GNU libtool silently ignores while slibtool does not.

It can be easily fixed by just removing `'(tpm2_totp)'`, but I am not sure what it was originally intended to be and was introduced in the `Initial code commit` commit.

https://github.com/tpm2-software/tpm2-totp/commit/e6f7d62b1f7873bf18a4ea75ef7be94225e0f778#diff-0462e381b2fb3286568215681c8983490a37ac9ae0f0c5ee304df7fa6426d4afR34

Also see this downstream issue: https://bugs.gentoo.org/777291