### PR TITLE
ci: enable coverity

### DIFF
--- a/.ci/coverity.run
+++ b/.ci/coverity.run
@@ -65,7 +65,7 @@ pushd "$DOCKER_BUILD_DIR"
 
 echo "Performing build with Coverity Scan"
 rm -rf cov-int
-./bootstrap && ./configure --enable-debug && make clean
+./bootstrap && ./configure --disable-defaultflags --enable-debug && make clean
 cov-build --dir $DOCKER_BUILD_DIR/cov-int make -j $(nproc)
 
 echo "Collecting Coverity data for submission"
@@ -75,22 +75,22 @@ AUTHOR_EMAIL="$(git log -1 $HEAD --pretty="%aE")"
 VERSION="$(git rev-parse HEAD)"
 echo "Name: $AUTHOR" >> README
 echo "Email: $AUTHOR_EMAIL" >> README
-echo "Project: tpm2-pkcs11" >> README
+echo "Project: $PROJECT" >> README
 echo "Build-Version: $VERSION" >> README
 echo "Description: $REPO_SLUG $REPO_BRANCH" >> README
-echo "Submitted-by: tpm2-pkcs11 CI" >> README
+echo "Submitted-by: $PROJECT CI" >> README
 echo "---README---"
 cat README
 echo "---EOF---"
 
-rm -f tpm2-pkcs11-scan.tgz
-tar -czf tpm2-pkcs11-scan.tgz README cov-int
+rm -f "$PROJECT-scan.tgz"
+tar -czf "$PROJECT-scan.tgz" README cov-int
 
 rm -rf README cov-int
 
 # upload the results
 echo "Testing for scan results..."
-scan_file=$(stat --printf='%n' tpm2-*-scan.tgz)
+scan_file=$(stat --printf='%n' "$PROJECT-scan.tgz")
 
 echo "Submitting data to Coverity"
 curl --form token="$COVERITY_SCAN_TOKEN" \
@@ -101,7 +101,7 @@ curl --form token="$COVERITY_SCAN_TOKEN" \
   --form description="$REPO_SLUG $REPO_BRANCH" \
   "https://scan.coverity.com/builds?project=$PROJECT"
 
-rm -rf tpm2-*-scan.tgz
+rm -rf "$PROJECT-scan.tgz"
 
 popd
 

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -3,6 +3,7 @@ on: push
 jobs:
   coverity-scan:
     runs-on: ubuntu-latest
+    environment: coverity
     if: contains(github.ref, 'coverity_scan')
     steps:
       - name: Check out repository
@@ -17,5 +18,5 @@ jobs:
           DOCKER_IMAGE: ubuntu-18.04
           CC: gcc
           COVERITY_SCAN_TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
-          COVERITY_SUBMISSION_EMAIL: william.c.roberts@intel.com
+          COVERITY_SUBMISSION_EMAIL: diabonas@gmx.de
         run: ./.ci/ci-runner.sh

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Linux Build Status](https://travis-ci.org/tpm2-software/tpm2-totp.svg?branch=master)](https://travis-ci.org/tpm2-software/tpm2-totp)
 [![Code Coverage](https://codecov.io/gh/tpm2-software/tpm2-totp/branch/master/graph/badge.svg)](https://codecov.io/gh/tpm2-software/tpm2-totp)
 [![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/tpm2-software/tpm2-totp.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/tpm2-software/tpm2-totp/context:cpp)
+[![Coverity Scan](https://scan.coverity.com/projects/22811/badge.svg)](https://scan.coverity.com/projects/tpm2-totp)
 
 # Overview
 This is a reimplementation of Matthew Garrett's


### PR DESCRIPTION
Enable coverity runs on the [`coverity_scan`](https://github.com/tpm2-software/tpm2-totp/tree/coverity_scan) branch (project was already created and successfully analysed, cf. https://scan.coverity.com/projects/tpm2-totp) and add a badge to the README file.