### PR TITLE
build: provide default value of systemdsystemunitdir for make distcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,8 @@ AM_CFLAGS       = $(INCLUDE_DIRS) $(EXTRA_CFLAGS) $(TSS2_ESYS_CFLAGS) \
 AM_LDFLAGS      = $(EXTRA_LDFLAGS) $(CODE_COVERAGE_LIBS)
 AM_LDADD        = $(TSS2_ESYS_LIBS) $(TSS2_MU_LIBS)
 
-AM_DISTCHECK_CONFIGURE_FLAGS = --with-dracutmodulesdir='$$(libdir)/dracut/modules.d'
+AM_DISTCHECK_CONFIGURE_FLAGS = --with-dracutmodulesdir='$$(libdir)/dracut/modules.d' \
+                               --with-systemdsystemunitdir='$$(libdir)/systemd/system'
 
 # Initialize empty variables to be extended throughout
 bin_PROGRAMS =


### PR DESCRIPTION
The same issue that has been fixed in #44 for `dracutmodulesdir` has resurfaced for `systemdsystemunitdir`: since it is derived using pkg-config, it doesn't respect `${prefix}`, making `make distcheck` fail (or install directly to the system directory instead of `DESTDIR` if invoked as root). Provide a value for `systemdsystemunitdir` derived from `${prefix}` that is used for distcheck.