### PR TITLE
Password from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,22 @@ the tpm2-totp hook in your initramfs generator and rebuild the initramfs.
 
 ## Setup
 The TOTP secret can be initialized with and without password. It is recommended to
-set a password `-P`in order to enable recovery options. Also the PCRs and PCR
-banks can be selected `-p` and `-b`. Default values are PCRs `0,2,4` and
-banks `SHA1, SHA256`.
+set a password `-P` in order to enable recovery options. Further, it is strongly
+recommended to provide the password via stdin, rather than directly as a
+command line option, to protect it from other processes, shell history, etc.
+Also the PCRs and PCR banks can be selected `-p` and `-b`. Default values are
+PCRs `0,2,4` and banks `SHA1, SHA256`.
 ```
 tpm2-totp init
+
+tpm2-totp -P - init
+verysecret<CTRL-D>
+# or (recommended)
+gpg --decrypt /path/to/password.gpg | tpm2-totp -P - init
+# or (discouraged)
 tpm2-totp -P verysecret init
-tpm2-totp -P verysecret -p 0,1,2,3,4,5,6 init
+
+tpm2-totp -P - -p 0,1,2,3,4,5,6 init
 tpm2-totp -p 0,1,2,3,4,5,6 -b SHA1,SHA256 init
 ```
 
@@ -89,12 +98,12 @@ tpm2-totp -t show
 ## Recovery
 In order to recover the QR code:
 ```
-tpm2-totp -P verysecret recover
+tpm2-totp -P - recover
 ```
 In order to reseal the secret:
 ```
-tpm2-totp -P verysecret reseal
-tpm2-totp -P verysecret -p 1,3,5,6 reseal
+tpm2-totp -P - reseal
+tpm2-totp -P - -p 1,3,5,6 reseal
 ```
 
 ## Deletion
@@ -107,10 +116,10 @@ tpm2-totp clean
 All command additionally take the `-N` option to specify the NV index to be
 used. By default, 0x018094AF is used and recommended.
 ```
-tpm2-totp -N 0x01800001 -P verysecret init
+tpm2-totp -N 0x01800001 -P - init
 tpm2-totp -N 0x01800001 show
-tpm2-totp -N 0x01800001 -P verysecret recover
-tpm2-totp -N 0x01800001 -P verysecret reseal
+tpm2-totp -N 0x01800001 -P - recover
+tpm2-totp -N 0x01800001 -P - reseal
 ```
 
 # Limitations

--- a/man/tpm2-totp.1.md
+++ b/man/tpm2-totp.1.md
@@ -61,6 +61,8 @@ options.
 
   * `-P <password>`, `--password <password>`:
     Password for the secret (default: none) (commands: init, recover, reseal)
+    Read from stdin if `-` (recommended).
+    Must not contain `\0`.
 
   * `-t`, `--time`:
     Display the date/time of the TOTP calculation (commands: show)
@@ -83,13 +85,22 @@ options.
 
 ## Setup
 The TOTP secret can be initialized with and without password. It is recommended to
-set a password `-P`in order to enable recovery options. Also the PCRs and PCR
-banks can be selected `-p` and `-b`. Default values are PCRs `0,2,4` and
-banks `SHA1, SHA256`.
+set a password `-P` in order to enable recovery options. Further, it is strongly
+recommended to provide the password via stdin, rather than directly as a
+command line option, to protect it from other processes, shell history, etc.
+Also the PCRs and PCR banks can be selected `-p` and `-b`. Default values are
+PCRs `0,2,4` and banks `SHA1, SHA256`.
 ```
 tpm2-totp init
+
+tpm2-totp -P - init
+verysecret<CTRL-D>
+# or (recommended)
+gpg --decrypt /path/to/password.gpg | tpm2-totp -P - init
+# or (discouraged)
 tpm2-totp -P verysecret init
-tpm2-totp -P verysecret -p 0,1,2,3,4,5,6 init
+
+tpm2-totp -P - -p 0,1,2,3,4,5,6 init
 tpm2-totp -p 0,1,2,3,4,5,6 -b SHA1,SHA256 init
 ```
 
@@ -105,12 +116,12 @@ tpm2-totp -t show
 ## Recovery
 In order to recover the QR code:
 ```
-tpm2-totp -P verysecret recover
+tpm2-totp -P - recover
 ```
 In order to reseal the secret:
 ```
-tpm2-totp -P verysecret reseal
-tpm2-totp -P verysecret -p 1,3,5,6 reseal
+tpm2-totp -P - reseal
+tpm2-totp -P - -p 1,3,5,6 reseal
 ```
 
 ## Deletion
@@ -123,10 +134,10 @@ tpm2-totp clean
 All command additionally take the `-N` option to specify the NV index to be
 used. By default, 0x018094AF is used and recommended.
 ```
-tpm2-totp -N 0x01800001 -P verysecret init
+tpm2-totp -N 0x01800001 -P - init
 tpm2-totp -N 0x01800001 show
-tpm2-totp -N 0x01800001 -P verysecret recover
-tpm2-totp -N 0x01800001 -P verysecret reseal
+tpm2-totp -N 0x01800001 -P - recover
+tpm2-totp -N 0x01800001 -P - reseal
 ```
 
 ## TCTI configuration

--- a/src/tpm2-totp.c
+++ b/src/tpm2-totp.c
@@ -38,7 +38,7 @@ char *help =
     "    -b, --banks     Selected PCR banks (default: SHA1,SHA256)\n"
     "    -l, --label     Label to use for display in the TOTP authenticator app (default: TPM2-TOTP)\n"
     "    -N, --nvindex   TPM NV index to store data (default: 0x018094AF)\n"
-    "    -P, --password  Password for recovery/resealing (default: None)\n"
+    "    -P, --password  Password for recovery/resealing (default: None). Read from stdin if '-' (recommended).\n"
     "    -p, --pcrs      Selected PCR registers (default: 0,2,4,6)\n"
     "    -t, --time      Show the time used for calculation\n"
     "    -T, --tcti      TCTI to use\n"

--- a/test/tpm2-totp.sh
+++ b/test/tpm2-totp.sh
@@ -28,6 +28,9 @@ fi
 
 tpm2-totp -P abc recover
 
+# Test reading password from stdin
+echo -n 'abc' | tpm2-totp -P - recover
+
 tpm2-totp -P abc -p 0,1,2,3,4,5,6 -b SHA1,SHA256 reseal
 
 # Changing an unselected PCR bank should not affect the TOTP calculation

--- a/test/tpm2-totp.sh
+++ b/test/tpm2-totp.sh
@@ -31,6 +31,11 @@ tpm2-totp -P abc recover
 # Test reading password from stdin
 echo -n 'abc' | tpm2-totp -P - recover
 
+if tpm2-totp -P wrongpassword recover; then
+    echo "The secret was recovered despite an incorrect password!"
+    exit 1
+fi
+
 tpm2-totp -P abc -p 0,1,2,3,4,5,6 -b SHA1,SHA256 reseal
 
 # Changing an unselected PCR bank should not affect the TOTP calculation


### PR DESCRIPTION
fixes #86

At the moment, this forbids `\0` in input stream, but allows `\n`, etc. Not sure if we want to restrict `--password` to single-line, printable ASCII only, or arbitrary binary secrets (and what about `\0` in that case).