### PR TITLE
Fix link in Install.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -38,7 +38,7 @@ sudo apt -y install \
   iproute2 \
   plymouth \
   libplymouth-dev
-git clone --depth=1 http://www.github.com/tpm2-software/tpm2-tss
+git clone --depth=1 https://github.com/tpm2-software/tpm2-totp
 cd tpm2-tss
 ./bootstrap
 ./configure


### PR DESCRIPTION
The link in the install instructions for Ubuntu point to a different tpm2-software repo. This PR fixes it. 