### PR TITLE
dist: show TOTP even if vconsole setup fails

### DIFF
--- a/dist/tpm2-totp.service.in
+++ b/dist/tpm2-totp.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Display a TOTP during boot
-Requires=systemd-vconsole-setup.service dev-tpm0.device
+Requires=dev-tpm0.device
+Wants=systemd-vconsole-setup.service
 After=systemd-vconsole-setup.service dev-tpm0.device
 Before=systemd-ask-password-console.service
 Conflicts=multi-user.target

--- a/dist/tpm2-totp.timer.in
+++ b/dist/tpm2-totp.timer.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=Display a TOTP every 30s during boot
-Requires=systemd-vconsole-setup.service dev-tpm0.device
+Requires=dev-tpm0.device
+Wants=systemd-vconsole-setup.service
 After=systemd-vconsole-setup.service dev-tpm0.device
 Before=systemd-ask-password-console.service
 Conflicts=multi-user.target


### PR DESCRIPTION
Change Requires= to Wants= for systemd-vconsole-setup.service. This allows
showing a code even if the vconsole setup fails (for example, because of a bad
font or bad keymap).